### PR TITLE
Move location of CardControls on Albums and Tracks screen

### DIFF
--- a/src/components/albums/AlbumsControls.tsx
+++ b/src/components/albums/AlbumsControls.tsx
@@ -61,17 +61,6 @@ const AlbumsControls: FC = () => {
             />
 
             <Flex gap={20} justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
-                {/* Card display settings */}
-                <CardControls
-                    cardSize={cardSize}
-                    cardGap={cardGap}
-                    showDetails={showDetails}
-                    cardSizeSetter={setAlbumsCardSize}
-                    cardGapSetter={setAlbumsCardGap}
-                    showDetailsSetter={setAlbumsShowDetails}
-                    resetter={resetAlbumsToDefaults}
-                />
-
                 {/* "Showing x of y albums" */}
                 <Flex gap={3} align="flex-end">
                     <Text size="xs" color={colors.gray[6]}>
@@ -96,6 +85,17 @@ const AlbumsControls: FC = () => {
                         albums
                     </Text>
                 </Flex>
+
+                {/* Card display settings */}
+                <CardControls
+                    cardSize={cardSize}
+                    cardGap={cardGap}
+                    showDetails={showDetails}
+                    cardSizeSetter={setAlbumsCardSize}
+                    cardGapSetter={setAlbumsCardGap}
+                    showDetailsSetter={setAlbumsShowDetails}
+                    resetter={resetAlbumsToDefaults}
+                />
             </Flex>
         </Flex>
     );

--- a/src/components/tracks/TracksControls.tsx
+++ b/src/components/tracks/TracksControls.tsx
@@ -38,17 +38,6 @@ const TracksControls: FC = () => {
             />
 
             <Flex gap={20} justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
-                {/* Card display settings */}
-                <CardControls
-                    cardSize={cardSize}
-                    cardGap={cardGap}
-                    showDetails={showDetails}
-                    cardSizeSetter={setTracksCardSize}
-                    cardGapSetter={setTracksCardGap}
-                    showDetailsSetter={setTracksShowDetails}
-                    resetter={resetTracksToDefaults}
-                />
-
                 {/* "Showing x of y tracks" */}
                 <Flex gap={3} align="flex-end">
                     <Text size="xs" color={colors.gray[6]}>
@@ -67,6 +56,17 @@ const TracksControls: FC = () => {
                         tracks
                     </Text>
                 </Flex>
+
+                {/* Card display settings */}
+                <CardControls
+                    cardSize={cardSize}
+                    cardGap={cardGap}
+                    showDetails={showDetails}
+                    cardSizeSetter={setTracksCardSize}
+                    cardGapSetter={setTracksCardGap}
+                    showDetailsSetter={setTracksShowDetails}
+                    resetter={resetTracksToDefaults}
+                />
             </Flex>
         </Flex>
     );


### PR DESCRIPTION
Relocated to far right, to match Presets. "Showing x of y" is now positioned to the left of the CardControls.