### PR TITLE
Move "has message data changed" check from websocket api to reducers

### DIFF
--- a/src/app/store/helpers.ts
+++ b/src/app/store/helpers.ts
@@ -1,0 +1,45 @@
+import { Draft } from "immer";
+import get from "lodash/get";
+import set from "lodash/set";
+
+type ComparablePayloadChunk = Draft<{ [key: number | string]: string }> | Map<any, any>;
+
+/**
+ * Compare the provided Draft object o1 with the provided o2. Return true if they appear to be
+ * identical.
+ *
+ * Warning: This uses JSON.stringify() on the two inputs to determine equivalence, which can in
+ * some situations return false negatives (say if the object key order has changed).
+ */
+export const quickObjectMatch = (o1: ComparablePayloadChunk, o2: ComparablePayloadChunk): boolean =>
+    JSON.stringify(o1) === JSON.stringify(o2);
+
+/**
+ * Only update the given Redux state if the newPayload is different from what's already in the
+ * current state (under the stateKey key).
+ *
+ * Note: It's OK to update the provided Redux state because RTK has wrapped it with immer:
+ *  https://redux-toolkit.js.org/usage/immer-reducers#redux-toolkit-and-immer
+ *
+ * ------------------------------------------------------------------------------------------------
+ * Why this function exists:
+ *
+ * This function exists for use by the reducers handling actions resulting from websocket messages
+ * received from the back-end.
+ *
+ * Normally a Redux action is expected to update state with its payload. However, the Vibin UI
+ * receives a lot of websocket messages from the back-end which contain unchanged information.
+ * Since these websocket messages are used to update Redux state via actions (see
+ * app/services/vibinWebsocket.ts), the action reducers want to check that their action payloads
+ * are actually new/different before updating state. That check is performed by this function.
+ *
+ * This check ensures that the Redux state will only be updated when a true data change is received
+ * from the back-end, which in turn minimizes redundant component renders.
+ * ------------------------------------------------------------------------------------------------
+ *
+ * @param state Redux state (note: this is assumed to be wrapped by Immer)
+ * @param stateKey The key to update (e.g. "someKey" or "parent.someKey")
+ * @param newPayload The new payload to compare and (possibly) use to update state
+ */
+export const updateIfDifferent = (state: any, stateKey: any, newPayload: any) =>
+    !quickObjectMatch(get(state, stateKey), newPayload) && set(state, stateKey, newPayload);

--- a/src/app/store/playbackSlice.ts
+++ b/src/app/store/playbackSlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
 import { Format, MediaId, MediaSourceClass, Stream, Track } from "../types";
+import { updateIfDifferent } from "./helpers";
 
 /**
  * The Playback slice is intended to contain information about the current playback status of the
@@ -109,34 +110,34 @@ export const playbackSlice = createSlice({
             state.playhead.position_normalized = 0;
         },
         setActiveTransportActions: (state, action: PayloadAction<TransportAction[]>) => {
-            state.active_transport_actions = action.payload;
+            updateIfDifferent(state, "active_transport_actions", action.payload);
         },
         setAudioSources: (state, action: PayloadAction<{ [key: number]: AudioSource }>) => {
-            state.audio_sources = action.payload;
+            updateIfDifferent(state, "audio_sources", action.payload);
         },
         setCurrentAudioSource: (state, action: PayloadAction<AudioSource | undefined>) => {
-            state.current_audio_source = action.payload;
+            updateIfDifferent(state, "current_audio_source", action.payload);
         },
-        setCurrentFormat: (state, action: PayloadAction<Format | undefined>) => {
-            state.current_format = action.payload;
+        setCurrentFormat: (state, action: PayloadAction<Partial<Format> | undefined>) => {
+            updateIfDifferent(state, "current_format", action.payload);
         },
         setCurrentStream: (state, action: PayloadAction<Stream | undefined>) => {
-            state.current_stream = action.payload;
+            updateIfDifferent(state, "current_stream", action.payload);
         },
-        setCurrentTrack: (state, action: PayloadAction<Track | undefined>) => {
-            state.current_track = action.payload;
+        setCurrentTrack: (state, action: PayloadAction<Partial<Track> | undefined>) => {
+            updateIfDifferent(state, "current_track", action.payload);
         },
         setCurrentTrackMediaId: (state, action: PayloadAction<MediaId | undefined>) => {
-            state.current_track_media_id = action.payload;
+            updateIfDifferent(state, "current_track_media_id", action.payload);
         },
         setCurrentAlbumMediaId: (state, action: PayloadAction<MediaId | undefined>) => {
-            state.current_album_media_id = action.payload;
+            updateIfDifferent(state, "current_album_media_id", action.payload);
         },
         setDeviceDisplay: (state, action: PayloadAction<DeviceDisplay>) => {
-            state.device_display = action.payload;
+            updateIfDifferent(state, "device_display", action.payload);
         },
         setPlayStatus: (state, action: PayloadAction<PlayStatus | undefined>) => {
-            state.play_status = action.payload;
+            updateIfDifferent(state, "play_status", action.payload);
         },
         setPlayheadPosition: (state, action: PayloadAction<number>) => {
             state.playhead.position = action.payload;
@@ -145,10 +146,10 @@ export const playbackSlice = createSlice({
             state.playhead.position_normalized = action.payload;
         },
         setRepeat: (state, action: PayloadAction<RepeatState | undefined>) => {
-            state.repeat = action.payload;
+            updateIfDifferent(state, "repeat", action.payload);
         },
         setShuffle: (state, action: PayloadAction<ShuffleState | undefined>) => {
-            state.shuffle = action.payload;
+            updateIfDifferent(state, "shuffle", action.payload);
         },
     },
 });

--- a/src/app/store/playlistSlice.ts
+++ b/src/app/store/playlistSlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
 import { Playlist } from "../types";
+import { updateIfDifferent } from "./helpers";
 
 /**
  * TODO: Determine whether both store/playlistSlice and services/vibinPlaylist should coexists.
@@ -23,10 +24,10 @@ export const playlistSlice = createSlice({
     initialState,
     reducers: {
         setCurrentTrackIndex: (state, action: PayloadAction<number | undefined>) => {
-            state.current_track_index = action.payload;
+            updateIfDifferent(state, "current_track_index", action.payload);
         },
         setEntries: (state, action: PayloadAction<Playlist | undefined>) => {
-            state.entries = action.payload;
+            updateIfDifferent(state, "entries", action.payload);
         },
     },
 });

--- a/src/app/store/presetsSlice.ts
+++ b/src/app/store/presetsSlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
 import { Preset } from "../services/vibinPresets";
+import { updateIfDifferent } from "./helpers";
 
 export interface PresetsState {
     start: number;
@@ -22,10 +23,10 @@ export const presetsSlice = createSlice({
     initialState,
     reducers: {
         setPresetsState: (state, action: PayloadAction<PresetsState>) => {
-            state.start = action.payload.start;
-            state.end = action.payload.end;
-            state.max_presets = action.payload.max_presets;
-            state.presets = action.payload.presets;
+            updateIfDifferent(state, "start", action.payload.start);
+            updateIfDifferent(state, "end", action.payload.end);
+            updateIfDifferent(state, "max_presets", action.payload.max_presets);
+            updateIfDifferent(state, "presets", action.payload.presets);
         },
     },
 });

--- a/src/app/store/systemSlice.ts
+++ b/src/app/store/systemSlice.ts
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
+import { updateIfDifferent } from "./helpers";
+
 export type PowerStatus = "on" | "off" | undefined;
 
 export interface SystemState {
@@ -34,13 +36,13 @@ export const systemSlice = createSlice({
     initialState,
     reducers: {
         setMediaDeviceName: (state, action: PayloadAction<string>) => {
-            state.media_device.name = action.payload;
+            updateIfDifferent(state, "media_device.name", action.payload);
         },
         setStreamerName: (state, action: PayloadAction<string>) => {
-            state.streamer.name = action.payload;
+            updateIfDifferent(state, "streamer.name", action.payload);
         },
         setStreamerPower: (state, action: PayloadAction<PowerStatus>) => {
-            state.streamer.power = action.payload;
+            updateIfDifferent(state, "streamer.power", action.payload);
         },
     },
 });

--- a/src/components/managers/MediaSourceManager.tsx
+++ b/src/components/managers/MediaSourceManager.tsx
@@ -29,16 +29,15 @@ const MediaSourceManager: FC = () => {
 
         // Announce the new media source; but not the very first time a media source is known (to
         // prevent the announcement always appearing when the app is first loaded).
-        // TODO: Re-enable this once the identical state update issue has been fixed
-        // if (haveIgnoredInitialState) {
-        //     currentSource && showSuccessNotification({
-        //         title: "Media Source set",
-        //         message: `Media source set to ${currentSource.name}`,
-        //     })
-        // }
-        // else {
-        //     currentSource?.name && setHaveIgnoredInitialState(true);
-        // }
+        if (haveIgnoredInitialState) {
+            currentSource && showSuccessNotification({
+                title: "Media Source changed",
+                message: `Media source set to ${currentSource.name}`,
+            })
+        }
+        else {
+            currentSource?.name && setHaveIgnoredInitialState(true);
+        }
     }, [dispatch, currentSource]);
 
     return null;

--- a/src/components/shared/PlayStateIndicator.tsx
+++ b/src/components/shared/PlayStateIndicator.tsx
@@ -50,8 +50,8 @@ const PlayStateIndicator: FC = () => {
             ),
         },
         ready: {
-            label: "Ready",
-            component: <Text size="xs">ready</Text>,
+            label: "Powered on, not playing",
+            component: <Text size="xs">powered on</Text>,
         },
         not_ready: {
             label: "Powered off",


### PR DESCRIPTION
Doing the message-data-vs-state-value check in the websocket api was broken (it never worked as it wasn't ever successfully retrieving the existing state information). The reducers now do this check.