### PR TITLE
Add navigation from Track to Album or Artist; add filter clear button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import NowPlayingScreen from "./components/layout/NowPlayingScreen";
 import PresetsScreen from "./components/layout/PresetsScreen";
 import PlaylistScreen from "./components/layout/PlaylistScreen";
 import PlayheadManager from "./components/managers/PlayheadManager";
+import MediaGroupsManager from "./components/managers/MediaGroupsManager";
 import MediaSourceManager from "./components/managers/MediaSourceManager";
 import TracksScreen from "./components/layout/TracksScreen";
 import WebsocketManager from "./components/managers/WebsocketManager";
@@ -112,6 +113,7 @@ export default function App() {
                 <Notifications limit={5} autoClose={3000} />
                 <WebsocketManager />
                 <PlayheadManager />
+                <MediaGroupsManager />
                 <MediaSourceManager />
                 <RouterProvider router={router} />
             </MantineProvider>

--- a/src/app/store/mediaGroupsSlice.ts
+++ b/src/app/store/mediaGroupsSlice.ts
@@ -1,0 +1,52 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+import { Album, Artist, Track } from "../types";
+
+export interface MediaGroupsState {
+    albumById: Record<string, Album>,
+    albumsByArtistName: Record<string, Album[]>,
+    artistByName: Record<string, Artist>;
+    tracksByAlbumId: Record<string, Track[]>,
+    tracksByArtistName: Record<string, Track[]>,
+}
+
+const initialState: MediaGroupsState = {
+    albumById: {},
+    albumsByArtistName: {},
+    artistByName: {},
+    tracksByAlbumId: {},
+    tracksByArtistName: {},
+};
+
+export const mediaGroupsSlice = createSlice({
+    name: "mediaGroups",
+    initialState,
+    reducers: {
+        setAlbumById: (state, action: PayloadAction<Record<string, Album>>) => {
+            state.albumById = action.payload;
+        },
+        setAlbumsByArtistName: (state, action: PayloadAction<Record<string, Album[]>>) => {
+            state.albumsByArtistName = action.payload;
+        },
+        setArtistByName: (state, action: PayloadAction<Record<string, Artist>>) => {
+            state.artistByName = action.payload;
+        },
+        setTracksByAlbumId: (state, action: PayloadAction<Record<string, Track[]>>) => {
+            state.tracksByAlbumId = action.payload;
+        },
+        setTracksByArtistName: (state, action: PayloadAction<Record<string, Track[]>>) => {
+            state.tracksByArtistName = action.payload;
+        },
+    },
+});
+
+export const {
+    setAlbumById,
+    setAlbumsByArtistName,
+    setArtistByName,
+    setTracksByAlbumId,
+    setTracksByArtistName,
+} = mediaGroupsSlice.actions;
+
+export default mediaGroupsSlice.reducer;

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -4,6 +4,7 @@ import { setupListeners } from "@reduxjs/toolkit/query";
 import internalReducer from "./internalSlice";
 import systemReducer from "./systemSlice";
 import favoritesReducer from "./favoritesSlice";
+import mediaGroupsReducer from "./mediaGroupsSlice";
 import playbackReducer from "./playbackSlice";
 import playlistReducer from "./playlistSlice";
 import presetsReducer from "./presetsSlice";
@@ -27,6 +28,7 @@ export const store = configureStore({
         internal: internalReducer,
         system: systemReducer,
         favorites: favoritesReducer,
+        mediaGroups: mediaGroupsReducer,
         playback: playbackReducer,
         playlist: playlistReducer,
         presets: presetsReducer,

--- a/src/app/workers/mediaGrouperWorker.ts
+++ b/src/app/workers/mediaGrouperWorker.ts
@@ -1,9 +1,11 @@
-import { Album, Track } from "../types";
+import { Album, Artist, Track } from "../types";
 
 type MediaGrouperMessageType =
+    | "albumById"
     | "allAlbumsByArtistName"
     | "allTracksByArtistName"
-    | "allTracksByAlbumId";
+    | "allTracksByAlbumId"
+    | "artistByName";
 
 type MediaGrouperMessage = {
     type: MediaGrouperMessageType;
@@ -13,9 +15,17 @@ type MediaGrouperMessage = {
 onmessage = (e) => {
     const { type, payload } = e.data as MediaGrouperMessage;
 
-    let result;
+    let result: any;
 
-    if (type === "allAlbumsByArtistName") {
+    if (type === "albumById") {
+        const r: Record<string, Album> = {};
+
+        for (const album of payload) {
+            r[album.id] = album;
+        }
+
+        result = r;
+    } else if (type === "allAlbumsByArtistName") {
         result = payload.reduce(
             // @ts-ignore
             (computedAlbumsByArtist, album) => {
@@ -60,6 +70,14 @@ onmessage = (e) => {
             },
             {}
         );
+    } else if (type === "artistByName") {
+        const r: Record<string, Artist> = {};
+
+        for (const artist of payload) {
+            r[artist.title] = artist;
+        }
+
+        result = r;
     }
 
     postMessage({ type, result });

--- a/src/components/albums/AlbumsControls.tsx
+++ b/src/components/albums/AlbumsControls.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
-import { Flex, Select, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Flex, Select, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { IconSquareX } from "@tabler/icons";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import {
@@ -52,7 +53,7 @@ const AlbumsControls: FC = () => {
                     ...STYLE_LABEL_BESIDE_COMPONENT,
                     input: {
                         width: 170,
-                    }
+                    },
                 }}
             />
 
@@ -63,6 +64,14 @@ const AlbumsControls: FC = () => {
                     placeholder="Filter by Album title"
                     label="Filter"
                     value={filterText}
+                    rightSection={
+                        <ActionIcon
+                            disabled={!filterText}
+                            onClick={() => dispatch(setAlbumsFilterText(""))}
+                        >
+                            <IconSquareX size="1.3rem" style={{ display: "block", opacity: 0.5 }} />
+                        </ActionIcon>
+                    }
                     onChange={(event) => dispatch(setAlbumsFilterText(event.target.value))}
                     styles={{
                         ...STYLE_LABEL_BESIDE_COMPONENT,

--- a/src/components/artists/ArtistsControls.tsx
+++ b/src/components/artists/ArtistsControls.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback, useEffect } from "react";
 import {
+    ActionIcon,
     Flex,
     Select,
     Text,
@@ -22,9 +23,9 @@ import {
 import { RootState } from "../../app/store/store";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import { useMediaGroupings } from "../../app/hooks/useMediaGroupings";
-import { useGetAlbumsQuery } from "../../app/services/vibinAlbums";
 import { useGetArtistsQuery } from "../../app/services/vibinArtists";
 import { useGetTracksQuery } from "../../app/services/vibinTracks";
+import { IconSquareX } from "@tabler/icons";
 
 const ArtistsControls: FC = () => {
     const dispatch = useAppDispatch();
@@ -83,22 +84,6 @@ const ArtistsControls: FC = () => {
             dispatch(setArtistsSelectedAlbum(currentAlbum));
             dispatch(setArtistsSelectedTrack(currentTrack));
         }
-
-        // // TODO: Clean this up once "current artist" is available alongside current artist/album;
-        // //  and once the current media ids are replaced with full Artist/Album/Track objects.
-        // const currentArtist = allArtists?.find(
-        //     (artist: Artist) => artist.title === currentTrack?.artist
-        // );
-        //
-        // const currentAlbum = allAlbums?.find((album: Album) => album.id === currentAlbumMediaId);
-        // const currentTrack = allTracks?.find((track: Track) => track.id === currentTrackMediaId);
-        //
-        // if (currentArtist && (currentAlbum || currentTrack)) {
-        //     dispatch(setArtistsFilterText(""));
-        //     dispatch(setArtistsSelectedArtist(currentArtist));
-        //     dispatch(setArtistsSelectedAlbum(currentAlbum));
-        //     dispatch(setArtistsSelectedTrack(currentTrack));
-        // }
     }
 
     const onArtistCollectionChange = useCallback((value: unknown) => {
@@ -150,7 +135,7 @@ const ArtistsControls: FC = () => {
                     ...STYLE_LABEL_BESIDE_COMPONENT,
                     input: {
                         width: 180,
-                    }
+                    },
                 }}
             />
 
@@ -159,6 +144,14 @@ const ArtistsControls: FC = () => {
                 placeholder="Filter by Artist name"
                 label="Filter"
                 value={filterText}
+                rightSection={
+                    <ActionIcon
+                        disabled={!filterText}
+                        onClick={() => dispatch(setArtistsFilterText(""))}
+                    >
+                        <IconSquareX size="1.3rem" style={{ display: "block", opacity: 0.5 }} />
+                    </ActionIcon>
+                }
                 disabled={activeCollection === "current"}
                 onChange={(event) => dispatch(setArtistsFilterText(event.target.value))}
                 styles={{

--- a/src/components/favorites/FavoritesControls.tsx
+++ b/src/components/favorites/FavoritesControls.tsx
@@ -10,7 +10,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from "@mantine/core";
-import { IconDisc, IconMicrophone2, IconPlayerPlay } from "@tabler/icons";
+import { IconDisc, IconMicrophone2, IconPlayerPlay, IconSquareX } from "@tabler/icons";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
@@ -79,6 +79,14 @@ const FavoritesControls: FC = () => {
                     placeholder="Filter by Favorite title"
                     label="Filter"
                     value={filterText}
+                    rightSection={
+                        <ActionIcon
+                            disabled={!filterText}
+                            onClick={() => dispatch(setFavoritesFilterText(""))}
+                        >
+                            <IconSquareX size="1.3rem" style={{ display: "block", opacity: 0.5 }} />
+                        </ActionIcon>
+                    }
                     onChange={(event) => dispatch(setFavoritesFilterText(event.target.value))}
                     styles={{
                         ...STYLE_LABEL_BESIDE_COMPONENT,

--- a/src/components/layout/NowPlayingScreen.tsx
+++ b/src/components/layout/NowPlayingScreen.tsx
@@ -18,7 +18,7 @@ import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { setNowPlayingActiveTab } from "../../app/store/userSettingsSlice";
 import { usePlayMutation } from "../../app/services/vibinTransport";
 import { useLazyGetTrackByIdQuery } from "../../app/services/vibinTracks";
-import AlbumArt from "../albums/AlbumArt";
+import TrackArt from "../tracks/TrackArt";
 import FieldValueList from "../fieldValueList/FieldValueList";
 import NowPlaying from "../currentlyPlaying/NowPlaying";
 import TrackLinks from "../nowPlaying/TrackLinks";
@@ -87,7 +87,7 @@ const NowPlayingScreen: FC = () => {
     const { activeTab } = useAppSelector((state: RootState) => state.userSettings.nowPlaying);
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
     const playStatus = useAppSelector((state: RootState) => state.playback.play_status);
-    const currentTrack = useAppSelector((state: RootState) => state.playback.current_track);
+    const [currentTrack, setCurrentTrack] = useState<Track | undefined>(undefined);
     const currentTrackId = useAppSelector(
         (state: RootState) => state.playback.current_track_media_id
     );
@@ -99,7 +99,7 @@ const NowPlayingScreen: FC = () => {
         currentTrackTitle: {
             fontFamily: APP_ALT_FONTFACE,
             lineHeight: 0.9,
-            height: "1.7rem",
+            minHeight: "1.7rem",
         },
     }))();
 
@@ -125,6 +125,7 @@ const NowPlayingScreen: FC = () => {
 
             let result = [year, genre].filter((value) => value !== undefined).join(" • ");
 
+            setCurrentTrack(track);
             setTrackYearAndGenre(result);
         }
     }, [getTrackResult]);
@@ -152,7 +153,7 @@ const NowPlayingScreen: FC = () => {
             {/* LHS stack: Album art, playhead, etc */}
             <Stack miw={albumArtWidth} maw={albumArtWidth}>
                 <Stack spacing="xs">
-                    <Flex justify="space-between">
+                    <Flex justify="space-between" align="flex-end">
                         <MediaSourceBadge showSource={true} />
 
                         {trackYearAndGenre && (
@@ -163,7 +164,13 @@ const NowPlayingScreen: FC = () => {
                     </Flex>
 
                     <Stack>
-                        <AlbumArt artUri={currentTrack.art_url} size={albumArtWidth} radius={5} />
+                        <TrackArt
+                            track={currentTrack}
+                            size={albumArtWidth}
+                            radius={5}
+                            actionCategories={["Favorites", "Navigation"]}
+                            hidePlayButton
+                        />
                         {playStatus === "pause" && <PlaybackPaused />}
                     </Stack>
 

--- a/src/components/managers/MediaGroupsManager.tsx
+++ b/src/components/managers/MediaGroupsManager.tsx
@@ -1,0 +1,47 @@
+import React, { FC, useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+// TODO: If this approach of munging the infrequently-changing list of albums and tracks and
+//  storing the result in application state is preferred, then other consumers of
+//  useMediaGroupings() should switch over to using the mediaGroups slice instead.
+//  useMediaGroupings() could also set application state itself, although this Manager (or
+//  something like it) would still need to exist so that something is using useMediaGroupings().
+
+import {
+    setAlbumById,
+    setAlbumsByArtistName,
+    setArtistByName,
+    setTracksByAlbumId,
+    setTracksByArtistName,
+} from "../../app/store/mediaGroupsSlice";
+import { useMediaGroupings } from "../../app/hooks/useMediaGroupings";
+
+const MediaGroupsManager: FC = () => {
+    const dispatch = useDispatch();
+    const { albumById, albumsByArtistName, artistByName, tracksByAlbumId, tracksByArtistName } =
+        useMediaGroupings();
+
+    useEffect(() => {
+        dispatch(setAlbumById(albumById));
+    }, [dispatch, albumById]);
+
+    useEffect(() => {
+        dispatch(setAlbumsByArtistName(albumsByArtistName));
+    }, [dispatch, albumsByArtistName]);
+
+    useEffect(() => {
+        dispatch(setArtistByName(artistByName));
+    }, [dispatch, artistByName]);
+
+    useEffect(() => {
+        dispatch(setTracksByAlbumId(tracksByAlbumId));
+    }, [dispatch, tracksByAlbumId]);
+
+        useEffect(() => {
+        dispatch(setTracksByArtistName(tracksByArtistName));
+    }, [dispatch, tracksByArtistName]);
+
+    return null;
+};
+
+export default MediaGroupsManager;

--- a/src/components/playlist/PlaylistEntryActionsButton.tsx
+++ b/src/components/playlist/PlaylistEntryActionsButton.tsx
@@ -1,13 +1,16 @@
 import React, { FC, useEffect, useState } from "react";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { useNavigate } from "react-router-dom";
 import { Box, createStyles, Menu, Tooltip, useMantineTheme } from "@mantine/core";
 import {
     IconArrowBarToDown,
     IconArrowBarToUp,
     IconCornerDownRightDouble,
+    IconDisc,
     IconDotsVertical,
     IconHeart,
     IconHeartOff,
+    IconMicrophone2,
     IconPlayerPlay,
     IconTrash
 } from "@tabler/icons";
@@ -23,7 +26,9 @@ import {
     useDeleteFavoriteMutation,
 } from "../../app/services/vibinFavorites";
 import { showErrorNotification, showSuccessNotification } from "../../app/utils";
-import { useAppSelector } from "../../app/hooks";
+import { setAlbumsActiveCollection, setAlbumsFilterText } from "../../app/store/userSettingsSlice";
+import { setTracksFilterText } from "../../app/store/userSettingsSlice";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { RootState } from "../../app/store/store";
 
 const useStyles = createStyles((theme) => ({
@@ -66,6 +71,8 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
     onOpen = undefined,
     onClose = undefined,
 }) => {
+    const dispatch = useAppDispatch();
+    const navigate = useNavigate();
     const { colors } = useMantineTheme();
     const [moveEntry, moveEntryStatus] = useMovePlaylistEntryIdMutation();
     const [deletePlaylistId, deleteStatus] = useDeletePlaylistEntryIdMutation();
@@ -210,7 +217,7 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                         >
                             Move to bottom
                         </Menu.Item>
-                        
+
                         {/* Favorites */}
                         <Menu.Label>Favorites</Menu.Label>
                         <Menu.Item
@@ -240,7 +247,33 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                             }}
                         >
                             Remove from Favorites
-                        </Menu.Item>                        
+                        </Menu.Item>
+
+                        {/* Navigation */}
+                        <Menu.Label>Navigation</Menu.Label>
+                        <Menu.Item
+                            icon={<IconDisc size={14} />}
+                            onClick={() => {
+                                dispatch(setAlbumsActiveCollection("all"));
+                                dispatch(
+                                    setAlbumsFilterText(`${entry.album} artist:(${entry.artist})`)
+                                );
+                                navigate("/ui/albums");
+                            }}
+                        >
+                            View in Albums
+                        </Menu.Item>
+                        <Menu.Item
+                            icon={<IconMicrophone2 size={14} />}
+                            onClick={() => {
+                                dispatch(
+                                    setTracksFilterText(`${entry.title} album:(${entry.album})`)
+                                );
+                                navigate("/ui/tracks");
+                            }}
+                        >
+                            View in Tracks
+                        </Menu.Item>
                     </>
                 </Menu.Dropdown>
             </Menu>

--- a/src/components/presets/PresetsControls.tsx
+++ b/src/components/presets/PresetsControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Flex, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Flex, Text, TextInput, useMantineTheme } from "@mantine/core";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import {
@@ -13,6 +13,7 @@ import { RootState } from "../../app/store/store";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import CardControls from "../shared/CardControls";
 import FilterInstructions from "../shared/FilterInstructions";
+import { IconSquareX } from "@tabler/icons";
 
 const PresetsControls: FC = () => {
     const dispatch = useAppDispatch();
@@ -32,6 +33,14 @@ const PresetsControls: FC = () => {
                     placeholder="Filter by Preset name"
                     label="Filter"
                     value={filterText}
+                    rightSection={
+                        <ActionIcon
+                            disabled={!filterText}
+                            onClick={() => dispatch(setPresetsFilterText(""))}
+                        >
+                            <IconSquareX size="1.3rem" style={{ display: "block", opacity: 0.5 }} />
+                        </ActionIcon>
+                    }
                     onChange={(event) => dispatch(setPresetsFilterText(event.target.value))}
                     styles={{
                         ...STYLE_LABEL_BESIDE_COMPONENT,

--- a/src/components/tracks/TracksControls.tsx
+++ b/src/components/tracks/TracksControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect } from "react";
-import { Flex, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Flex, Text, TextInput, useMantineTheme } from "@mantine/core";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import {
@@ -16,6 +16,7 @@ import { useAppConstants } from "../../app/hooks/useAppConstants";
 import CardControls from "../shared/CardControls";
 import FilterInstructions from "../shared/FilterInstructions";
 import { useDebouncedValue } from "@mantine/hooks";
+import { IconSquareX } from "@tabler/icons";
 
 const lyricsSearchFinder = new RegExp(/(lyrics?):(\([^)]+?\)|[^( ]+)/);
 
@@ -51,6 +52,14 @@ const TracksControls: FC = () => {
                     placeholder="Filter by Track title"
                     label="Filter"
                     value={filterText}
+                    rightSection={
+                        <ActionIcon
+                            disabled={!filterText}
+                            onClick={() => dispatch(setTracksFilterText(""))}
+                        >
+                            <IconSquareX size="1.3rem" style={{ display: "block", opacity: 0.5 }} />
+                        </ActionIcon>
+                    }
                     onChange={(event) => dispatch(setTracksFilterText(event.target.value))}
                     styles={{
                         ...STYLE_LABEL_BESIDE_COMPONENT,


### PR DESCRIPTION
Can also navigate from Album to Artist.

Includes experiment in storing mediaGroupings in Redux state, so it can be accessed anywhere in the app without having to use the custom useMediaGroupings() hook. (The hook approach results in a copy of the media groups -- including compute time -- for each consumer).