### PR TITLE
Have Now Playing screen report the current media source when playing

### DIFF
--- a/src/components/layout/NowPlayingScreen.tsx
+++ b/src/components/layout/NowPlayingScreen.tsx
@@ -137,7 +137,14 @@ const NowPlayingScreen: FC = () => {
     }
 
     if (playStatus === "ready" || !currentTrack) {
-        return (
+        return playStatus === "play" ? (
+            <Center pt="xl">
+                <Flex gap={10} align="center">
+                    <Text size={16} weight="bold">Currently playing from</Text>
+                    <MediaSourceBadge />
+                </Flex>
+            </Center>
+        ) : (
             <Center pt="xl">
                 <SadLabel label="Nothing is currently playing" />
             </Center>


### PR DESCRIPTION
This is for media sources which support very limited actions (just "play") -- such as the CD input. Now the UI will report that it's playing from the current source, rather than reporting that nothing is playing.