### PR TITLE
Improve layout and functionality of Artists screen

### DIFF
--- a/src/app/store/internalSlice.ts
+++ b/src/app/store/internalSlice.ts
@@ -25,6 +25,15 @@ export interface InternalState {
             renderWidth: number;
             renderHeight: number;
         };
+        scrollPos: {
+            artists: number;
+            albums: number;
+            tracks: number;
+        };
+        scrollCurrentIntoView: () => void;
+        scrollSelectedIntoView: () => void;
+        scrollToCurrentOnScreenEnter: boolean;
+        scrollToSelectedOnScreenEnter: boolean;
     };
     favorites: {
         filteredFavoriteCount: number;
@@ -71,6 +80,15 @@ const initialState: InternalState = {
             renderWidth: 200,
             renderHeight: 200,
         },
+        scrollPos: {
+            artists: 0,
+            albums: 0,
+            tracks: 0,
+        },
+        scrollCurrentIntoView: () => {},
+        scrollSelectedIntoView: () => {},
+        scrollToCurrentOnScreenEnter: false,
+        scrollToSelectedOnScreenEnter: false,
     },
     favorites: {
         // Number of favorites currently displayed in the Favorites screen.
@@ -113,6 +131,24 @@ export const internalSlice = createSlice({
         ) => {
             state.artists.artistCard.renderWidth = action.payload.width;
             state.artists.artistCard.renderHeight = action.payload.height;
+        },
+        setArtistsScrollPos: (
+            state,
+            action: PayloadAction<{ category: "artists" | "albums" | "tracks"; pos: number }>
+        ) => {
+            state.artists.scrollPos[action.payload.category] = action.payload.pos;
+        },
+        setArtistsScrollCurrentIntoView: (state, action: PayloadAction<() => void>) => {
+            state.artists.scrollCurrentIntoView = action.payload;
+        },
+        setArtistsScrollSelectedIntoView: (state, action: PayloadAction<() => void>) => {
+            state.artists.scrollSelectedIntoView = action.payload;
+        },
+        setArtistsScrollToCurrentOnScreenEnter: (state, action: PayloadAction<boolean>) => {
+            state.artists.scrollToCurrentOnScreenEnter = action.payload;
+        },
+        setArtistsScrollToSelectedOnScreenEnter: (state, action: PayloadAction<boolean>) => {
+            state.artists.scrollToSelectedOnScreenEnter = action.payload;
         },
         setCurrentScreen: (state, action: PayloadAction<string>) => {
             state.application.currentScreen = action.payload;
@@ -173,6 +209,11 @@ export const internalSlice = createSlice({
 export const {
     setAlbumCardRenderDimensions,
     setArtistCardRenderDimensions,
+    setArtistsScrollPos,
+    setArtistsScrollCurrentIntoView,
+    setArtistsScrollSelectedIntoView,
+    setArtistsScrollToCurrentOnScreenEnter,
+    setArtistsScrollToSelectedOnScreenEnter,
     setCurrentScreen,
     setFavoriteCardRenderDimensions,
     setIsComputingInBackground,

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -49,7 +49,9 @@ export const store = configureStore({
         [vibinWebsocket.reducerPath]: vibinWebsocket.reducer,
     },
     middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware().concat(
+        getDefaultMiddleware({
+            serializableCheck: false, // Some functions, like scroll handlers, are stored in state
+        }).concat(
             localStorageMiddleware.middleware,
             vibinAlbumsApi.middleware,
             vibinArtistsApi.middleware,

--- a/src/components/artists/ArtistWall.tsx
+++ b/src/components/artists/ArtistWall.tsx
@@ -1,19 +1,30 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
     Box,
     Center,
     createStyles,
+    Divider,
     Flex,
+    ScrollArea,
     Stack,
     Text,
     useMantineTheme,
 } from "@mantine/core";
+import get from "lodash/get";
+import throttle from "lodash/throttle";
 
 import { Album, Artist, MediaId, Track } from "../../app/types";
 import type { RootState } from "../../app/store/store";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { useGetArtistsQuery } from "../../app/services/vibinArtists";
-import { setFilteredArtistCount } from "../../app/store/internalSlice";
+import {
+    setArtistsScrollCurrentIntoView,
+    setArtistsScrollPos,
+    setArtistsScrollSelectedIntoView,
+    setArtistsScrollToCurrentOnScreenEnter,
+    setArtistsScrollToSelectedOnScreenEnter,
+    setFilteredArtistCount,
+} from "../../app/store/internalSlice";
 import {
     setArtistsSelectedAlbum,
     setArtistsSelectedArtist,
@@ -24,14 +35,18 @@ import ArtistCard from "./ArtistCard";
 import TrackCard from "../tracks/TrackCard";
 import LoadingDataMessage from "../shared/LoadingDataMessage";
 import SadLabel from "../shared/SadLabel";
-import { useMediaGroupings } from "../../app/hooks/useMediaGroupings";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import { useGetTracksQuery } from "../../app/services/vibinTracks";
+import { store } from "../../app/store/store";
+
+const safeGet = (mediaData: Record<string, any>, key: string) => get(mediaData, key, []);
+
+const SCROLL_POS_DISPATCH_RATE = 500;
 
 const ArtistWall: FC = () => {
     const { colors } = useMantineTheme();
     const dispatch = useAppDispatch();
-    const { SCREEN_LOADING_PT } = useAppConstants();
+    const { HEADER_HEIGHT, SCREEN_HEADER_HEIGHT, SCREEN_LOADING_PT } = useAppConstants();
     const { data: allArtists, error, isLoading } = useGetArtistsQuery();
     const { data: allTracks } = useGetTracksQuery();
     const { activeCollection, selectedAlbum, selectedArtist, selectedTrack, viewMode } =
@@ -45,9 +60,19 @@ const ArtistWall: FC = () => {
     const currentTrackMediaId = useAppSelector(
         (state: RootState) => state.playback.current_track_media_id
     );
-    const { allAlbumsByArtistName, allTracksByAlbumId, allTracksByArtistName } =
-        useMediaGroupings();
+    const { albumsByArtistName, tracksByAlbumId, tracksByArtistName } = useAppSelector(
+        (state: RootState) => state.mediaGroups
+    );
     const [artistIdsWithAlbums, setArtistIdsWithAlbums] = useState<MediaId[]>([]);
+    const artistsViewport = useRef<HTMLDivElement>(null);
+    const albumsViewport = useRef<HTMLDivElement>(null);
+    const tracksViewport = useRef<HTMLDivElement>(null);
+    const artistSelectedScrollRef = useRef<HTMLDivElement>(null);
+    const albumSelectedScrollRef = useRef<HTMLDivElement>(null);
+    const trackSelectedScrollRef = useRef<HTMLDivElement>(null);
+    const artistCurrentScrollRef = useRef<HTMLDivElement>(null);
+    const albumCurrentScrollRef = useRef<HTMLDivElement>(null);
+    const trackCurrentScrollRef = useRef<HTMLDivElement>(null);
 
     const { classes: dynamicClasses } = createStyles((theme) => ({
         artistWall: {
@@ -68,7 +93,7 @@ const ArtistWall: FC = () => {
 
         // @ts-ignore
         const withAlbums: MediaId[] = allArtists.reduce((accum, artist) => {
-            if (allAlbumsByArtistName(artist.title).length > 0) {
+            if (safeGet(albumsByArtistName, artist.title).length > 0) {
                 return [...accum, artist.id];
             }
 
@@ -76,7 +101,133 @@ const ArtistWall: FC = () => {
         }, []);
 
         setArtistIdsWithAlbums(withAlbums);
-    }, [allArtists, allAlbumsByArtistName, artistIdsWithAlbums]);
+    }, [allArtists, albumsByArtistName, artistIdsWithAlbums]);
+
+    // --------------------------------------------------------------------------------------------
+    // Scroll position restoration.
+    //
+    // Whenever the <ScrollArea> is updated, the y-position is stored in application state (once
+    // each for Artists, Albums, and Tracks). The update rate is throttled by
+    // SCROLL_POS_DISPATCH_RATE for performance reasons.
+    //
+    // When the component is re-mounted, the <ScrollArea> components are reset back to their last
+    // recorded position.
+
+    // Store the current scroll positions.
+    const throttledArtistsPosChange = useCallback(
+        throttle(
+            (value) => {
+                dispatch(setArtistsScrollPos({ category: "artists", pos: value.y }));
+            },
+            SCROLL_POS_DISPATCH_RATE,
+            { leading: false }
+        ),
+        []
+    );
+
+    const throttledAlbumsPosChange = useCallback(
+        throttle(
+            (value) => {
+                dispatch(setArtistsScrollPos({ category: "albums", pos: value.y }));
+            },
+            SCROLL_POS_DISPATCH_RATE,
+            { leading: false }
+        ),
+        []
+    );
+
+    const throttledTracksPosChange = useCallback(
+        throttle(
+            (value) => {
+                dispatch(setArtistsScrollPos({ category: "tracks", pos: value.y }));
+            },
+            SCROLL_POS_DISPATCH_RATE,
+            { leading: false }
+        ),
+        []
+    );
+
+    // When the Artist Wall mounts, do one of the follow:
+    //  * Scroll to the current track if requested.
+    //  * Scroll to the selected Artist/Album/Track if requested (this is used by the
+    //      navigation options, like "View in Artists" from the Album/Track/etc screens.
+    //  * Restore the last-recorded manual scroll positions.
+    useEffect(() => {
+        const { scrollToCurrentOnScreenEnter, scrollToSelectedOnScreenEnter } =
+            store.getState().internal.artists;
+
+        // TODO: Figure out how to properly determine when a scroll can be safely performed. The
+        //  setTimeout calls here are a hack which are likely to not work as hoped in different
+        //  environments. The goal is to only attempt a scroll once all the scrollable entries are
+        //  fully rendered.
+
+        if (scrollToCurrentOnScreenEnter) {
+            dispatch(setArtistsScrollToCurrentOnScreenEnter(false));
+            setTimeout(() => {
+                scrollCurrentIntoView();
+            }, 100);
+        } else if (scrollToSelectedOnScreenEnter) {
+            dispatch(setArtistsScrollToSelectedOnScreenEnter(false));
+            setTimeout(() => {
+                scrollSelectedIntoView();
+            }, 100);
+        } else {
+            // Restore last-recorded manual scroll positions.
+            const {
+                artists: artistsScrollPos,
+                albums: albumsScrollPos,
+                tracks: tracksScrollPos,
+            } = store.getState().internal.artists.scrollPos;
+
+            setTimeout(() => {
+                artistsViewport.current &&
+                    artistsScrollPos &&
+                    artistsViewport.current.scrollTo({ top: artistsScrollPos });
+
+                albumsViewport.current &&
+                    albumsScrollPos &&
+                    albumsViewport.current.scrollTo({ top: albumsScrollPos });
+
+                tracksViewport.current &&
+                    tracksScrollPos &&
+                    tracksViewport.current.scrollTo({ top: tracksScrollPos });
+            }, 1);
+        }
+    }, []);
+
+    const scrollSelectedIntoView = useCallback(() => {
+        artistsViewport.current?.scrollTo({ top: artistSelectedScrollRef.current?.offsetTop });
+        albumsViewport.current?.scrollTo({ top: albumSelectedScrollRef.current?.offsetTop });
+        tracksViewport.current?.scrollTo({ top: trackSelectedScrollRef.current?.offsetTop });
+    }, [
+        artistsViewport,
+        albumsViewport,
+        tracksViewport,
+        artistSelectedScrollRef,
+        albumSelectedScrollRef,
+        trackSelectedScrollRef,
+    ]);
+
+    useEffect(() => {
+        dispatch(setArtistsScrollSelectedIntoView(scrollSelectedIntoView));
+    }, [dispatch, scrollSelectedIntoView]);
+
+    const scrollCurrentIntoView = useCallback(() => {
+        artistsViewport.current?.scrollTo({ top: artistCurrentScrollRef.current?.offsetTop });
+        albumsViewport.current?.scrollTo({ top: albumCurrentScrollRef.current?.offsetTop });
+        tracksViewport.current?.scrollTo({ top: trackCurrentScrollRef.current?.offsetTop });
+    }, [
+        artistsViewport,
+        albumsViewport,
+        tracksViewport,
+        artistCurrentScrollRef,
+        albumCurrentScrollRef,
+        trackCurrentScrollRef,
+    ]);
+
+    useEffect(() => {
+        dispatch(setArtistsScrollCurrentIntoView(scrollCurrentIntoView));
+    }, [dispatch, scrollCurrentIntoView]);
 
     // --------------------------------------------------------------------------------------------
 
@@ -104,18 +255,6 @@ const ArtistWall: FC = () => {
         );
     }
 
-    // Determine which artists to display. This is triggered by the "Show" dropdown in the
-    // <ArtistsControls> component, and will be one of:
-    //
-    // 1. All artists.
-    // 2. Only artists with 1 or more albums.
-    // 3. What's currently playing, in which case limit the artist list to the selected artist
-    //      (the ArtistsControls will have set this artist in application state).
-
-    //     const currentArtist = allArtists?.find(
-    //         (artist: Artist) => artist.title === currentAlbum?.artist
-    //     );
-
     // --------------------------------------------------------------------------------------------
     // Find the current artist based on the current track. This is a brittle comparison.
     // TODO: Remove this once the app has a notion of a "current artist").
@@ -124,6 +263,14 @@ const ArtistWall: FC = () => {
     const currentArtist: Artist | undefined =
         currentTrack && allArtists.find((artist) => artist.title === currentTrack.artist);
     // --------------------------------------------------------------------------------------------
+
+    // Determine which artists to display. This is triggered by the "Show" dropdown in the
+    // <ArtistsControls> component, and will be one of:
+    //
+    // 1. All artists.
+    // 2. Only artists with 1 or more albums.
+    // 3. What's currently playing, in which case limit the artist list to the selected artist
+    //      (the ArtistsControls will have set this artist in application state).
 
     const artistsToDisplay: Artist[] =
         activeCollection === "current"
@@ -158,8 +305,6 @@ const ArtistWall: FC = () => {
     // Main render
     // --------------------------------------------------------------------------------------------
 
-    const minWidth = "25%";
-
     return viewMode === "art_focused" ? (
         <Box className={dynamicClasses.artistWall}>
             {artistsToDisplay
@@ -169,130 +314,225 @@ const ArtistWall: FC = () => {
                 ))}
         </Box>
     ) : (
-        <Flex gap={20} pb={15}>
+        <Flex
+            gap={10}
+            pb={15}
+            sx={{
+                height: `calc(100vh - ${HEADER_HEIGHT + SCREEN_HEADER_HEIGHT + 20}px)`,
+                overflowY: "hidden",
+            }}
+        >
             {/* Artists ----------------------------------------------------------------------- */}
 
-            <Stack miw={minWidth}>
-                <Text transform="uppercase" weight="bold" color={colors.dark[2]}>
-                    Artist
-                </Text>
-                <Stack spacing="xs">
-                    {/* Artist list */}
-                    {artistsToDisplay.map((artist) => (
-                        <ArtistCard
-                            key={artist.id}
-                            type="compact"
-                            artist={artist}
-                            albums={allAlbumsByArtistName(artist.title)}
-                            tracks={allTracksByArtistName(artist.title)}
-                            selected={artist.id === selectedArtist?.id}
-                            // TODO: Remove isCurentlyPlaying (it's replaced by highlightIfPlaying)
-                            //  once the "current artist" notion is properly handled.
-                            isCurrentlyPlaying={artist.id === currentArtist?.id}
-                            onClick={(artist: Artist) => {
-                                dispatch(setArtistsSelectedArtist(artist));
-                                dispatch(setArtistsSelectedAlbum(undefined));
-                            }}
-                        />
-                    ))}
+            <Stack spacing={10}>
+                <Stack spacing={2}>
+                    <Text transform="uppercase" weight="bold" color={colors.dark[2]}>
+                        Artist
+                    </Text>
+                    <Divider color={colors.dark[6]} pb={0} />
                 </Stack>
+                <ScrollArea
+                    viewportRef={artistsViewport}
+                    onScrollPositionChange={throttledArtistsPosChange}
+                    offsetScrollbars
+                >
+                    <Stack spacing="xs">
+                        {/* Artist list */}
+                        {artistsToDisplay.map((artist) => (
+                            <Box
+                                key={artist.id}
+                                ref={
+                                    artist.title === currentArtist?.title
+                                        ? artistCurrentScrollRef
+                                        : artist.id === selectedArtist?.id
+                                        ? artistSelectedScrollRef
+                                        : undefined
+                                }
+                            >
+                                <ArtistCard
+                                    type="compact"
+                                    artist={artist}
+                                    albums={safeGet(albumsByArtistName, artist.title)}
+                                    tracks={safeGet(tracksByArtistName, artist.title)}
+                                    selected={artist.id === selectedArtist?.id}
+                                    // TODO: Remove isCurrentlyPlaying (it's replaced by highlightIfPlaying)
+                                    //  once the "current artist" notion is properly handled.
+                                    isCurrentlyPlaying={artist.id === currentArtist?.id}
+                                    onClick={(artist: Artist) => {
+                                        dispatch(setArtistsSelectedArtist(artist));
+                                        dispatch(setArtistsSelectedAlbum(undefined));
+                                    }}
+                                />
+                            </Box>
+                        ))}
+                    </Stack>
+                </ScrollArea>
             </Stack>
 
             {/* Albums ------------------------------------------------------------------------ */}
 
-            <Stack miw={minWidth}>
-                <Text transform="uppercase" weight="bold" color={colors.dark[2]}>
-                    Albums
-                </Text>
-                <Stack spacing="xs">
-                    {selectedArtist ? (
-                        allAlbumsByArtistName(selectedArtist.title).length > 0 ? (
-                            // Artist with Albums
-                            allAlbumsByArtistName(selectedArtist.title).map((album) => {
-                                // console.log(`SELECTED: ${selectedAlbum?.id} -> ${album.id}`);
-                                return (
-                                    <AlbumCard
-                                        key={album.id}
+            <Stack spacing={10}>
+                <Stack spacing={2}>
+                    <Text transform="uppercase" weight="bold" color={colors.dark[2]}>
+                        Albums
+                    </Text>
+                    <Divider color={colors.dark[6]} pb={0} />
+                </Stack>
+                <ScrollArea
+                    viewportRef={albumsViewport}
+                    onScrollPositionChange={throttledAlbumsPosChange}
+                    offsetScrollbars
+                >
+                    <Stack spacing="xs">
+                        {selectedArtist ? (
+                            safeGet(albumsByArtistName, selectedArtist.title).length > 0 ? (
+                                // Artist with Albums
+                                safeGet(albumsByArtistName, selectedArtist.title).map(
+                                    (album: Album) => {
+                                        return (
+                                            <Box
+                                                key={album.id}
+                                                ref={
+                                                    album.id === currentAlbumMediaId
+                                                        ? albumCurrentScrollRef
+                                                        : album.id === selectedAlbum?.id
+                                                        ? albumSelectedScrollRef
+                                                        : undefined
+                                                }
+                                            >
+                                                <AlbumCard
+                                                    type="compact"
+                                                    album={album}
+                                                    tracks={safeGet(tracksByAlbumId, album.id)}
+                                                    enabledActions={{
+                                                        Favorites: ["all"],
+                                                        Navigation: [
+                                                            "ViewInAlbums",
+                                                            "ViewInTracks",
+                                                        ],
+                                                        Playlist: ["all"],
+                                                        Tracks: ["all"],
+                                                    }}
+                                                    selected={album.id === selectedAlbum?.id}
+                                                    onClick={(album: Album) =>
+                                                        dispatch(setArtistsSelectedAlbum(album))
+                                                    }
+                                                />
+                                            </Box>
+                                        );
+                                    }
+                                )
+                            ) : (
+                                // Artist with no Albums
+                                <Text
+                                    size="sm"
+                                    transform="uppercase"
+                                    weight="bold"
+                                    color={colors.dark[3]}
+                                    w={250}
+                                >
+                                    Artist has no Albums
+                                </Text>
+                            )
+                        ) : (
+                            <Text
+                                size="sm"
+                                transform="uppercase"
+                                weight="bold"
+                                color={colors.dark[3]}
+                                w={250}
+                            >
+                                No artist selected
+                            </Text>
+                        )}
+                    </Stack>
+                </ScrollArea>
+            </Stack>
+
+            {/* Tracks ------------------------------------------------------------------------ */}
+
+            <Stack spacing={10}>
+                <Stack spacing={2}>
+                    <Text transform="uppercase" weight="bold" color={colors.dark[2]}>
+                        Tracks
+                    </Text>
+                    <Divider color={colors.dark[6]} pb={0} />
+                </Stack>
+                <ScrollArea
+                    viewportRef={tracksViewport}
+                    onScrollPositionChange={throttledTracksPosChange}
+                    offsetScrollbars
+                >
+                    <Stack spacing="xs">
+                        {selectedAlbum ? (
+                            // Tracks for an Artist + Album selection
+                            safeGet(tracksByAlbumId, selectedAlbum.id).map((track: Track) => (
+                                <Box
+                                    key={track.id}
+                                    ref={
+                                        track.id === selectedTrack?.id
+                                            ? trackSelectedScrollRef
+                                            : undefined
+                                    }
+                                >
+                                    <TrackCard
                                         type="compact"
-                                        album={album}
-                                        tracks={allTracksByAlbumId(album.id)}
+                                        track={track}
+                                        showArt={false}
                                         enabledActions={{
                                             Favorites: ["all"],
                                             Navigation: ["ViewInAlbums", "ViewInTracks"],
                                             Playlist: ["all"],
                                             Tracks: ["all"],
                                         }}
-                                        selected={album.id === selectedAlbum?.id}
-                                        onClick={(album: Album) =>
-                                            dispatch(setArtistsSelectedAlbum(album))
+                                        selected={track.id === selectedTrack?.id}
+                                        onClick={(track: Track) =>
+                                            dispatch(setArtistsSelectedTrack(track))
                                         }
                                     />
-                                );
-                            })
+                                </Box>
+                            ))
+                        ) : selectedArtist &&
+                          safeGet(albumsByArtistName, selectedArtist.title).length <= 0 ? (
+                            // Tracks for an Artist with no Albums
+                            safeGet(tracksByArtistName, selectedArtist.title).map(
+                                (track: Track) => (
+                                    <Box
+                                        ref={
+                                            track.id === currentTrackMediaId
+                                                ? trackCurrentScrollRef
+                                                : track.id === selectedTrack?.id
+                                                ? trackSelectedScrollRef
+                                                : undefined
+                                        }
+                                    >
+                                        <TrackCard
+                                            key={track.id}
+                                            type="compact"
+                                            track={track}
+                                            showArt={false}
+                                            selected={track.id === selectedTrack?.id}
+                                            onClick={(track: Track) =>
+                                                dispatch(setArtistsSelectedTrack(track))
+                                            }
+                                        />
+                                    </Box>
+                                )
+                            )
                         ) : (
-                            // Artist with no Albums
+                            // Artist has Albums but none are selected, so no Tracks to display
                             <Text
                                 size="sm"
                                 transform="uppercase"
                                 weight="bold"
                                 color={colors.dark[3]}
+                                w={250}
                             >
-                                Artist has no Albums
+                                No album selected
                             </Text>
-                        )
-                    ) : (
-                        <Text size="sm" transform="uppercase" weight="bold" color={colors.dark[3]}>
-                            No artist selected
-                        </Text>
-                    )}
-                </Stack>
-            </Stack>
-
-            {/* Tracks ------------------------------------------------------------------------ */}
-
-            <Stack miw={minWidth}>
-                <Text transform="uppercase" weight="bold" color={colors.dark[2]}>
-                    Tracks
-                </Text>
-                <Stack spacing="xs">
-                    {selectedAlbum ? (
-                        // Tracks for an Artist + Album selection
-                        allTracksByAlbumId(selectedAlbum.id).map((track: Track) => (
-                            <TrackCard
-                                key={track.id}
-                                type="compact"
-                                track={track}
-                                showArt={false}
-                                enabledActions={{
-                                    Favorites: ["all"],
-                                    Navigation: ["ViewInAlbums", "ViewInTracks"],
-                                    Playlist: ["all"],
-                                    Tracks: ["all"],
-                                }}
-                                selected={track.id === selectedTrack?.id}
-                                onClick={(track: Track) => dispatch(setArtistsSelectedTrack(track))}
-                            />
-                        ))
-                    ) : selectedArtist &&
-                      allAlbumsByArtistName(selectedArtist.title).length <= 0 ? (
-                        // Tracks for an Artist with no Albums
-                        allTracksByArtistName(selectedArtist.title).map((track: Track) => (
-                            <TrackCard
-                                key={track.id}
-                                type="compact"
-                                track={track}
-                                showArt={false}
-                                selected={track.id === selectedTrack?.id}
-                                onClick={(track: Track) => dispatch(setArtistsSelectedTrack(track))}
-                            />
-                        ))
-                    ) : (
-                        // Artist has Albums but none are selected
-                        <Text size="sm" transform="uppercase" weight="bold" color={colors.dark[3]}>
-                            No album selected
-                        </Text>
-                    )}
-                </Stack>
+                        )}
+                    </Stack>
+                </ScrollArea>
             </Stack>
         </Flex>
     );

--- a/src/components/layout/NowPlayingScreen.tsx
+++ b/src/components/layout/NowPlayingScreen.tsx
@@ -178,7 +178,7 @@ const NowPlayingScreen: FC = () => {
                             hidePlayButton
                             enabledActions={{
                                 Favorites: ["all"],
-                                Navigation: ["all"],
+                                Navigation: ["ViewCurrentInArtists", "ViewInAlbums"],
                                 Playlist: ["all"],
                             }}
                         />

--- a/src/components/shared/CompactArtCard.tsx
+++ b/src/components/shared/CompactArtCard.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from "react";
-import { Box, createStyles, Flex, Image, Paper, Stack } from "@mantine/core";
+import { Box, Center, createStyles, Flex, Image, Paper, Stack } from "@mantine/core";
 
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 
@@ -44,18 +44,19 @@ const CompactArtCard: FC<CompactArtCardProps> = ({
         <Paper
             radius={5}
             pr={10}
+            miw={300}
             className={dynamicClasses.compactArtCard}
             onClick={() => onClick && onClick()}
         >
-            <Flex align="center" justify="space-between" gap={10} w="100%">
-                <Flex align="center">
+            <Flex align="flex-start" justify="space-between" gap={10} w="100%">
+                <Flex align="flex-start">
                     {artUrl &&
                         <Image src={artUrl} width={70} height={70} radius={5} fit="cover" />
                     }
                     <Stack spacing={5} p={10}>{children}</Stack>
                 </Flex>
 
-                <Box sx={{ alignSelf: "right" }}>{actions}</Box>
+                <Box sx={{ alignSelf: "center" }}>{actions}</Box>
             </Flex>
         </Paper>
     );

--- a/src/components/shared/MediaActionsButton.tsx
+++ b/src/components/shared/MediaActionsButton.tsx
@@ -36,11 +36,20 @@ import {
     setArtistsSelectedTrack,
     setTracksFilterText
 } from "../../app/store/userSettingsSlice";
+import {
+    setArtistsScrollToCurrentOnScreenEnter,
+    setArtistsScrollToSelectedOnScreenEnter,
+} from "../../app/store/internalSlice";
 
 export type MediaType = "album" | "track";
 
 export type FavoritesAction = "all" | "AddFavorite" | "RemoveFavorite";
-export type NavigationAction = "all" | "ViewInArtists" | "ViewInAlbums" | "ViewInTracks";
+export type NavigationAction =
+    | "all"
+    | "ViewCurrentInArtists"
+    | "ViewInArtists"
+    | "ViewInAlbums"
+    | "ViewInTracks";
 export type PlaylistAction =
     | "all"
     | "AppendToEnd"
@@ -128,6 +137,7 @@ const MediaActionsButton: FC<MediaActionsButtonProps> = ({
     const [deleteFavorite, deleteFavoriteStatus] = useDeleteFavoriteMutation();
     const { favorites } = useAppSelector((state: RootState) => state.favorites);
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
+    const source = useAppSelector((state: RootState) => state.playback.current_audio_source);
     const albumById = useAppSelector((state: RootState) => state.mediaGroups.albumById);
     const artistByName = useAppSelector((state: RootState) => state.mediaGroups.artistByName);
     const [showTracksModal, setShowTracksModal] = useState<boolean>(false);
@@ -159,6 +169,12 @@ const MediaActionsButton: FC<MediaActionsButtonProps> = ({
     const wantAction = (callerActions: MediaAction[], action: MediaAction): boolean =>
         callerActions.some((callerAction) => [action, "all"].includes(callerAction));
 
+    const wantViewInArtists = wantAction(enabledActions.Navigation!!, "ViewInArtists");
+    const wantViewCurrentInArtists = wantAction(
+        enabledActions.Navigation!!,
+        "ViewCurrentInArtists"
+    );
+    
     return (
         <Box onClick={(event) => event.stopPropagation()}>
             <Menu
@@ -364,7 +380,7 @@ const MediaActionsButton: FC<MediaActionsButtonProps> = ({
                         <>
                             <Menu.Label>Navigation</Menu.Label>
 
-                            {wantAction(enabledActions.Navigation!!, "ViewInArtists") && (
+                            {(wantViewInArtists || wantViewCurrentInArtists) && (
                                 <Menu.Item
                                     icon={<IconUser size={14} />}
                                     onClick={() => {
@@ -387,6 +403,11 @@ const MediaActionsButton: FC<MediaActionsButtonProps> = ({
                                             );
                                             dispatch(setArtistsSelectedTrack(media as Track));
                                         }
+
+                                        wantViewInArtists &&
+                                            dispatch(setArtistsScrollToSelectedOnScreenEnter(true));
+                                        wantViewCurrentInArtists &&
+                                            dispatch(setArtistsScrollToCurrentOnScreenEnter(true));
 
                                         navigate("/ui/artists");
                                     }}

--- a/src/components/tracks/TrackArt.tsx
+++ b/src/components/tracks/TrackArt.tsx
@@ -89,7 +89,6 @@ const TrackArt: FC<TrackArtProps> = ({
 }) => {
     const [addMediaToPlaylist, addStatus] = useAddMediaToPlaylistMutation();
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
-    const source = useAppSelector((state: RootState) => state.playback.current_audio_source);
     const [isActionsMenuOpen, setIsActionsMenuOpen] = useState<boolean>(false);
     const { classes } = useStyles();
 
@@ -118,7 +117,7 @@ const TrackArt: FC<TrackArtProps> = ({
             />
 
             {/* Only show the track controls for locally-streamed media */}
-            {track && showControls && source && source.class === "stream.media" && (
+            {track && showControls && (
                 <Flex
                     p="xs"
                     justify="space-between"

--- a/src/components/tracks/TrackCard.tsx
+++ b/src/components/tracks/TrackCard.tsx
@@ -50,7 +50,7 @@ const TrackCardCompact: FC<TrackCardTypeProps> = ({
     onClick,
 }) => {
     const currentTrackMediaId = useAppSelector(
-        (state: RootState) => state.playback.current_album_media_id
+        (state: RootState) => state.playback.current_track_media_id
     );
 
     const isCurrentlyPlaying = currentTrackMediaId === track.id;


### PR DESCRIPTION
* Make Artists, Albums, and Tracks separately scrollable
* Refine layout of `<CompactArtCard>`
* Remember scroll position when re-entering screen
* Add ability to scroll items to match selection or currently-playing
* Allow selection or currently-playing to be scrolled to on screen enter
* Leverage new scroll features when navigating to artists from elsewhere
* Fix bug preventing current track from being properly highlighted