### PR TITLE
Add ability to view track lyrics, waveform, and links, from menus

### DIFF
--- a/src/components/albums/AlbumArt.tsx
+++ b/src/components/albums/AlbumArt.tsx
@@ -74,10 +74,10 @@ const AlbumArt: FC<AlbumArtProps> = ({
     radius = 0,
     showControls = true,
     enabledActions = {
+        Details: ["all"],
         Favorites: ["all"],
         Navigation: ["ViewInArtists", "ViewInTracks"],
         Playlist: ["all"],
-        Tracks: ["all"],
     },
     size = 150,
     actionsMenuPosition,

--- a/src/components/albums/AlbumCard.tsx
+++ b/src/components/albums/AlbumCard.tsx
@@ -75,7 +75,7 @@ const AlbumCardCompact: FC<AlbumCardTypeProps> = ({
                             Favorites: ["all"],
                             Navigation: ["ViewInArtists", "ViewInTracks"],
                             Playlist: ["all"],
-                            Tracks: ["all"],
+                            Details: ["all"],
                         }
                     }
                     size="sm"
@@ -146,7 +146,7 @@ const AlbumCardArtFocused: FC<AlbumCardTypeProps> = ({
                             Favorites: ["all"],
                             Navigation: ["ViewInArtists", "ViewInTracks"],
                             Playlist: ["all"],
-                            Tracks: ["all"],
+                            Details: ["all"],
                         }
                     }
                     size={sizeOverride ? sizeOverride - borderSize * 2 : cardSize - borderSize * 2}

--- a/src/components/artists/ArtistWall.tsx
+++ b/src/components/artists/ArtistWall.tsx
@@ -405,13 +405,13 @@ const ArtistWall: FC = () => {
                                                     album={album}
                                                     tracks={safeGet(tracksByAlbumId, album.id)}
                                                     enabledActions={{
+                                                        Details: ["all"],
                                                         Favorites: ["all"],
                                                         Navigation: [
                                                             "ViewInAlbums",
                                                             "ViewInTracks",
                                                         ],
                                                         Playlist: ["all"],
-                                                        Tracks: ["all"],
                                                     }}
                                                     selected={album.id === selectedAlbum?.id}
                                                     onClick={(album: Album) =>
@@ -480,10 +480,10 @@ const ArtistWall: FC = () => {
                                         track={track}
                                         showArt={false}
                                         enabledActions={{
+                                            Details: ["all"],
                                             Favorites: ["all"],
                                             Navigation: ["ViewInAlbums", "ViewInTracks"],
                                             Playlist: ["all"],
-                                            Tracks: ["all"],
                                         }}
                                         selected={track.id === selectedTrack?.id}
                                         onClick={(track: Track) =>

--- a/src/components/favorites/FavoritesWall.tsx
+++ b/src/components/favorites/FavoritesWall.tsx
@@ -130,10 +130,10 @@ const FavoritesWall: FC = () => {
                             key={favorite.id}
                             album={favorite as Album}
                             enabledActions={{
+                                Details: ["all"],
                                 Favorites: ["all"],
                                 Navigation: ["all"],
                                 Playlist: ["all"],
-                                Tracks: ["all"],
                             }}
                             sizeOverride={cardSize}
                             detailsOverride={showDetails}
@@ -161,10 +161,10 @@ const FavoritesWall: FC = () => {
                             key={favorite.id}
                             track={favorite as Track}
                             enabledActions={{
+                                Details: ["all"],
                                 Favorites: ["all"],
                                 Navigation: ["all"],
                                 Playlist: ["all"],
-                                Tracks: ["all"],
                             }}
                             sizeOverride={cardSize}
                             detailsOverride={showDetails}

--- a/src/components/nowPlaying/Waveform.tsx
+++ b/src/components/nowPlaying/Waveform.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useRef, useState } from "react";
-import { Box, createStyles, Image } from "@mantine/core";
+import { Box, Center, createStyles, Flex, Image, Loader, Text } from "@mantine/core";
 import Draggable, { DraggableData } from "react-draggable";
 
 import { MediaId } from "../../app/types";
@@ -115,9 +115,10 @@ type WaveformProps = {
     trackId: MediaId;
     width?: number;
     height?: number;
+    showProgress?: boolean;
 };
 
-const Waveform: FC<WaveformProps> = ({ trackId, width = 800, height = 250 }) => {
+const Waveform: FC<WaveformProps> = ({ trackId, width = 800, height = 250, showProgress = true }) => {
     const { classes } = useStyles();
 
     return (
@@ -126,7 +127,7 @@ const Waveform: FC<WaveformProps> = ({ trackId, width = 800, height = 250 }) => 
                 src={`/tracks/${trackId}/waveform.png?width=${width}&height=${height}`}
                 radius={5}
             />
-            <WaveformProgress />
+            {showProgress && <WaveformProgress />}
         </Box>
     );
 };

--- a/src/components/shared/MediaSummaryBanner.tsx
+++ b/src/components/shared/MediaSummaryBanner.tsx
@@ -1,0 +1,71 @@
+import React, { FC } from "react";
+import { Box, Flex, Stack, Text, useMantineTheme } from "@mantine/core";
+
+import { Album, Track } from "../../app/types";
+import { yearFromDate } from "../../app/utils";
+import AlbumArt from "../albums/AlbumArt";
+import TrackArt from "../tracks/TrackArt";
+import MediaActionsButton from "./MediaActionsButton";
+
+type MediaSummaryBannerProps = {
+    media: Album | Track;
+    showArtControls?: boolean;
+    showSeparateActionsButton?: boolean;
+};
+
+const MediaSummaryBanner: FC<MediaSummaryBannerProps> = ({
+    media,
+    showArtControls = false,
+    showSeparateActionsButton = false,
+}) => {
+    const { colors } = useMantineTheme();
+
+    const isTrack = "album" in media;
+
+    return (
+        <Flex gap="md" justify="space-between">
+            {isTrack ? (
+                <TrackArt
+                    track={media as Track}
+                    size={100}
+                    showControls={showArtControls}
+                    actionsMenuPosition={"bottom"}
+                />
+            ) : (
+                <AlbumArt
+                    album={media as Album}
+                    size={100}
+                    showControls={showArtControls}
+                    actionsMenuPosition={"bottom"}
+                />
+            )}
+
+            <Stack sx={{ gap: 0, flexGrow: 1 }}>
+                <Text size="lg" weight="bold" sx={{ lineHeight: 1.25 }}>
+                    {media.title}
+                </Text>
+                <Text size="md" sx={{ lineHeight: 1.25 }}>
+                    {media.artist}
+                </Text>
+                <Text size="xs" weight="bold" color={colors.dark[3]}>
+                    {(media.date && yearFromDate(media.date)) || ""}
+                    {media.genre && media.genre.toLowerCase() !== "unknown"
+                        ? ` • ${media.genre.toUpperCase()}`
+                        : ""}
+                </Text>
+            </Stack>
+
+            {showSeparateActionsButton && (
+                <Box pr={5}>
+                    <MediaActionsButton
+                        media={media}
+                        mediaType={isTrack ? "track" : "album"}
+                        position="bottom"
+                    />
+                </Box>
+            )}
+        </Flex>
+    );
+};
+
+export default MediaSummaryBanner;

--- a/src/components/tracks/AlbumTracks.tsx
+++ b/src/components/tracks/AlbumTracks.tsx
@@ -3,9 +3,9 @@ import { Box, Center, createStyles, Flex, Paper, Stack, Text } from "@mantine/co
 
 import { useGetAlbumTracksQuery } from "../../app/services/vibinAlbums";
 import { Album, Track } from "../../app/types";
-import { secstoHms, yearFromDate } from "../../app/utils";
+import { secstoHms } from "../../app/utils";
 import MediaActionsButton from "../shared/MediaActionsButton";
-import AlbumArt from "../albums/AlbumArt";
+import MediaSummaryBanner from "../shared/MediaSummaryBanner";
 import AppendToPlaylistButton from "./AppendToPlaylistButton";
 import LoadingDataMessage from "../shared/LoadingDataMessage";
 import SadLabel from "../shared/SadLabel";
@@ -44,35 +44,13 @@ const AlbumTracks: FC<AlbumTracksProps> = ({ album }) => {
     return (
         <Stack>
             {/* Album details */}
-            <Flex gap="md" justify="space-between">
-                <AlbumArt album={album} size={100} actionsMenuPosition={"bottom"} />
-
-                <Stack sx={{ gap: 0, flexGrow: 1 }}>
-                    <Text size="lg" weight="bold" sx={{ lineHeight: 1.25 }}>
-                        {album.title}
-                    </Text>
-                    <Text size="md" sx={{ lineHeight: 1.25 }}>
-                        {album.artist}
-                    </Text>
-                    <Text size="xs" weight="bold" color={DIMMED}>
-                        {yearFromDate(album.date) || ""}
-                        {album.genre && album.genre.toLowerCase() !== "unknown"
-                            ? ` • ${album.genre.toUpperCase()}`
-                            : ""}
-                    </Text>
-                </Stack>
-
-                <Box pr={5}>
-                    <MediaActionsButton
-                        media={album}
-                        mediaType="album"
-                        position="bottom"
-                    />
-                </Box>
-            </Flex>
+            <MediaSummaryBanner
+                media={album}
+                showArtControls={true}
+                showSeparateActionsButton={true}
+            />
 
             {/* Track details */}
-
             {isLoading && (
                 // Tracks currently being loaded.
                 <Center pt={20}>

--- a/src/components/tracks/TrackArt.tsx
+++ b/src/components/tracks/TrackArt.tsx
@@ -76,10 +76,10 @@ const TrackArt: FC<TrackArtProps> = ({
     radius = 0,
     showControls = true,
     enabledActions = {
+        Details: ["all"],
         Favorites: ["all"],
         Navigation: ["ViewInArtists", "ViewInAlbums"],
         Playlist: ["all"],
-        Tracks: ["all"],
     },
     hidePlayButton = false,
     size = 150,

--- a/src/components/tracks/TrackCard.tsx
+++ b/src/components/tracks/TrackCard.tsx
@@ -67,7 +67,7 @@ const TrackCardCompact: FC<TrackCardTypeProps> = ({
                             Favorites: ["all"],
                             Navigation: ["ViewInArtists", "ViewInAlbums"],
                             Playlist: ["all"],
-                            Tracks: ["all"],
+                            Details: ["all"],
                         }
                     }
                     position="bottom"

--- a/src/components/tracks/TrackLinksModal.tsx
+++ b/src/components/tracks/TrackLinksModal.tsx
@@ -1,0 +1,38 @@
+import React, { FC } from "react";
+import { Box, Modal, Stack } from "@mantine/core";
+
+import { Track } from "../../app/types";
+import { useAppConstants } from "../../app/hooks/useAppConstants";
+import MediaSummaryBanner from "../shared/MediaSummaryBanner";
+import TrackLinks from "../nowPlaying/TrackLinks";
+
+type TrackLinksModalProps = {
+    track: Track;
+    opened: boolean;
+    onClose?: () => void;
+};
+
+const TrackLinksModal: FC<TrackLinksModalProps> = ({ track, opened, onClose = undefined }) => {
+    const { APP_MODAL_BLUR } = useAppConstants();
+
+    return (
+        <Modal
+            title={track.title}
+            centered
+            size="md"
+            radius={7}
+            overlayProps={{ blur: APP_MODAL_BLUR }}
+            opened={opened}
+            onClose={() => onClose && onClose()}
+        >
+            <Stack>
+                <MediaSummaryBanner media={track} />
+                <Box pt={10} pb={10}>
+                    <TrackLinks trackId={track.id} />
+                </Box>
+            </Stack>
+        </Modal>
+    );
+};
+
+export default TrackLinksModal;

--- a/src/components/tracks/TrackLyricsModal.tsx
+++ b/src/components/tracks/TrackLyricsModal.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from "react";
+import { Modal, ScrollArea, Stack } from "@mantine/core";
+
+import { Track } from "../../app/types";
+import { useAppConstants } from "../../app/hooks/useAppConstants";
+import MediaSummaryBanner from "../shared/MediaSummaryBanner";
+import TrackLyrics from "../nowPlaying/TrackLyrics";
+
+type TrackLyricsModalProps = {
+    track: Track;
+    opened: boolean;
+    onClose?: () => void;
+};
+
+const TrackLyricsModal: FC<TrackLyricsModalProps> = ({ track, opened, onClose = undefined }) => {
+    const { APP_MODAL_BLUR } = useAppConstants();
+
+    return (
+        <Modal
+            title={track.title}
+            centered
+            size="lg"
+            radius={7}
+            overlayProps={{ blur: APP_MODAL_BLUR }}
+            opened={opened}
+            onClose={() => onClose && onClose()}
+        >
+            <Stack>
+                <MediaSummaryBanner media={track} />
+
+                <ScrollArea h={`calc(80vh - 275px)`}>
+                    <TrackLyrics trackId={track.id} />
+                </ScrollArea>
+            </Stack>
+        </Modal>
+    );
+};
+
+export default TrackLyricsModal;

--- a/src/components/tracks/TrackWaveformModal.tsx
+++ b/src/components/tracks/TrackWaveformModal.tsx
@@ -1,0 +1,40 @@
+import React, { FC } from "react";
+import { Modal, Stack } from "@mantine/core";
+
+import { Track } from "../../app/types";
+import { useAppConstants } from "../../app/hooks/useAppConstants";
+import MediaSummaryBanner from "../shared/MediaSummaryBanner";
+import Waveform from "../nowPlaying/Waveform";
+
+type TrackWaveformModalProps = {
+    track: Track;
+    opened: boolean;
+    onClose?: () => void;
+};
+
+const TrackWaveformModal: FC<TrackWaveformModalProps> = ({
+    track,
+    opened,
+    onClose = undefined,
+}) => {
+    const { APP_MODAL_BLUR } = useAppConstants();
+
+    return (
+        <Modal
+            title={track.title}
+            centered
+            size="xl"
+            radius={7}
+            overlayProps={{ blur: APP_MODAL_BLUR }}
+            opened={opened}
+            onClose={() => onClose && onClose()}
+        >
+            <Stack>
+                <MediaSummaryBanner media={track} />
+                <Waveform trackId={track.id} width={2048} height={700} showProgress={false} />
+            </Stack>
+        </Modal>
+    );
+};
+
+export default TrackWaveformModal;


### PR DESCRIPTION
Added to both `<MediaActionsButton>` and `<PlaylistEntryActionsButton>`. Also factored out new `<MediaSummaryBanner>` component to share between new Lyrics, Waveform, and Links modals, as well as the previously- existing `<AlbumTracks>`.