### PR TITLE
Visually improve `<ErrorBoundary>`; handle invalid client routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,10 @@ export default function App() {
                     element: <StatusScreen />,
                 },
                 {
+                    path: "*",
+                    element: <Navigate to="/ui/albums" replace />,
+                },
+                {
                     index: true,
                     element: <Navigate to="/ui/albums" replace />,
                 },

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,14 +1,34 @@
 import React, { FC } from "react";
-import { Stack, Text } from "@mantine/core";
+import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+import { Stack, Text, useMantineTheme } from "@mantine/core";
 
-// TODO: Improve this
+import VibinLogo from "../layout/VibinLogo";
 
 const ErrorBoundary: FC = () => {
+    const { colors } = useMantineTheme();
+    const error = useRouteError();
+
+    console.error("vibin error", error);
+
     return (
-        <Stack>
-            <Text>Error</Text>
+        <Stack w="100%" align="center" pt={50}>
+            <VibinLogo />
+
+            {isRouteErrorResponse(error) ? (
+                <Stack spacing={15}>
+                    <Text
+                        transform="uppercase"
+                        weight="bold'"
+                    >{`[${error.status}] ${error.statusText}`}</Text>
+                    {error.data?.message && (
+                        <Text color={colors.gray[6]}>{error.data.message}</Text>
+                    )}
+                </Stack>
+            ) : (
+                <Text>Apologies, an unexpected error has occurred.</Text>
+            )}
         </Stack>
-    )
-}
+    );
+};
 
 export default ErrorBoundary;


### PR DESCRIPTION
Invalid client routes redirect to `/ui/albums`.