### PR TITLE
Add ability to play filtered media ids from Albums and Tracks screens

### DIFF
--- a/src/app/services/vibinPlaylist.ts
+++ b/src/app/services/vibinPlaylist.ts
@@ -93,8 +93,20 @@ export const vibinPlaylistApi = createApi({
                 method: "POST",
             }),
         }),
+        setPlaylistMediaIds: builder.mutation<void, { mediaIds: MediaId[] }>({
+            query: ({ mediaIds }) => ({
+                url: `modify`,
+                method: "POST",
+                body: {
+                    action: "REPLACE",
+                    media_ids: mediaIds,
+                },
+            }),
+        }),
     }),
 });
+
+// TODO: Consider using Query not Mutation (as a naming convention)
 
 export const {
     useAddMediaToPlaylistMutation,
@@ -105,4 +117,5 @@ export const {
     usePlayFavoriteTracksMutation,
     usePlayPlaylistEntryIdMutation,
     usePlayPlaylistEntryIndexMutation,
+    useSetPlaylistMediaIdsMutation,
 } = vibinPlaylistApi;

--- a/src/app/store/internalSlice.ts
+++ b/src/app/store/internalSlice.ts
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
+import { MediaId } from "../types";
+
 export type WebsocketStatus = "disconnected" | "connecting" | "connected" | "waiting_to_reconnect";
 
 export interface InternalState {
@@ -15,6 +17,7 @@ export interface InternalState {
     };
     albums: {
         filteredAlbumCount: number;
+        filteredAlbumMediaIds: MediaId[];
         albumCard: {
             renderWidth: number;
             renderHeight: number;
@@ -22,6 +25,7 @@ export interface InternalState {
     };
     artists: {
         filteredArtistCount: number;
+        filteredArtistMediaIds: MediaId[];
         artistCard: {
             renderWidth: number;
             renderHeight: number;
@@ -38,6 +42,7 @@ export interface InternalState {
     };
     favorites: {
         filteredFavoriteCount: number;
+        filteredFavoriteMediaIds: MediaId[];
         favoriteCard: {
             renderWidth: number;
             renderHeight: number;
@@ -48,9 +53,11 @@ export interface InternalState {
     };
     presets: {
         filteredPresetCount: number;
+        filteredPresetIds: number[];
     };
     tracks: {
         filteredTrackCount: number;
+        filteredTrackMediaIds: MediaId[];
         trackCard: {
             renderWidth: number;
             renderHeight: number;
@@ -71,6 +78,7 @@ const initialState: InternalState = {
     albums: {
         // Number of albums currently displayed in the Albums screen.
         filteredAlbumCount: 0,
+        filteredAlbumMediaIds: [],
         albumCard: {
             // Dimensions of the last-rendered AlbumCard, to inform not-visible AlbumCard container sizes.
             renderWidth: 200,
@@ -80,6 +88,7 @@ const initialState: InternalState = {
     artists: {
         // Number of artists currently displayed in the Albums screen.
         filteredArtistCount: 0,
+        filteredArtistMediaIds: [],
         artistCard: {
             // Dimensions of the last-rendered AlbumCard, to inform not-visible AlbumCard container sizes.
             renderWidth: 200,
@@ -98,6 +107,7 @@ const initialState: InternalState = {
     favorites: {
         // Number of favorites currently displayed in the Favorites screen.
         filteredFavoriteCount: 0,
+        filteredFavoriteMediaIds: [],
         favoriteCard: {
             // Dimensions of the last-rendered FavoriteCard, to inform not-visible FavoriteCard container sizes.
             renderWidth: 200,
@@ -110,10 +120,12 @@ const initialState: InternalState = {
     presets: {
         // Number of presets currently displayed in the Presets screen.
         filteredPresetCount: 0,
+        filteredPresetIds: [],
     },
     tracks: {
         // Number of tracks currently displayed in the Tracks screen.
         filteredTrackCount: 0,
+        filteredTrackMediaIds: [],
         trackCard: {
             // Dimensions of the last-rendered TrackCard, to inform not-visible TrackCard container sizes.
             renderWidth: 200,
@@ -182,17 +194,32 @@ export const internalSlice = createSlice({
         setFilteredAlbumCount: (state, action: PayloadAction<number>) => {
             state.albums.filteredAlbumCount = action.payload;
         },
+        setFilteredAlbumMediaIds: (state, action: PayloadAction<MediaId[]>) => {
+            state.albums.filteredAlbumMediaIds = action.payload;
+        },
         setFilteredArtistCount: (state, action: PayloadAction<number>) => {
             state.artists.filteredArtistCount = action.payload;
+        },
+        setFilteredArtistMediaIds: (state, action: PayloadAction<MediaId[]>) => {
+            state.artists.filteredArtistMediaIds = action.payload;
         },
         setFilteredFavoriteCount: (state, action: PayloadAction<number>) => {
             state.favorites.filteredFavoriteCount = action.payload;
         },
+        setFilteredFavoriteMediaIds: (state, action: PayloadAction<MediaId[]>) => {
+            state.favorites.filteredFavoriteMediaIds = action.payload;
+        },
         setFilteredPresetCount: (state, action: PayloadAction<number>) => {
             state.presets.filteredPresetCount = action.payload;
         },
+        setFilteredPresetIds: (state, action: PayloadAction<number[]>) => {
+            state.presets.filteredPresetIds = action.payload;
+        },
         setFilteredTrackCount: (state, action: PayloadAction<number>) => {
             state.tracks.filteredTrackCount = action.payload;
+        },
+        setFilteredTrackMediaIds: (state, action: PayloadAction<MediaId[]>) => {
+            state.tracks.filteredTrackMediaIds = action.payload;
         },
         setPlaylistScrollPos: (state, action: PayloadAction<number>) => {
             state.playlist.scrollPos = action.payload;
@@ -233,10 +260,15 @@ export const {
     setFavoriteCardRenderDimensions,
     setIsComputingInBackground,
     setFilteredAlbumCount,
+    setFilteredAlbumMediaIds,
     setFilteredArtistCount,
+    setFilteredArtistMediaIds,
     setFilteredFavoriteCount,
+    setFilteredFavoriteMediaIds,
     setFilteredPresetCount,
+    setFilteredPresetIds,
     setFilteredTrackCount,
+    setFilteredTrackMediaIds,
     setPlaylistScrollPos,
     setShowDebugPanel,
     setShowKeyboardShortcuts,

--- a/src/components/albums/AlbumWall.tsx
+++ b/src/components/albums/AlbumWall.tsx
@@ -8,7 +8,7 @@ import LoadingDataMessage from "../shared/LoadingDataMessage";
 import SadLabel from "../shared/SadLabel";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { useGetAlbumsQuery, useGetNewAlbumsQuery } from "../../app/services/vibinAlbums";
-import { setFilteredAlbumCount } from "../../app/store/internalSlice";
+import { setFilteredAlbumMediaIds } from "../../app/store/internalSlice";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import { collectionFilter } from "../../app/utils";
 
@@ -74,7 +74,7 @@ const AlbumWall: FC = () => {
 
     const albumsToDisplay = collectionFilter(collection, filterText, "title");
 
-    dispatch(setFilteredAlbumCount(albumsToDisplay.length));
+    dispatch(setFilteredAlbumMediaIds(albumsToDisplay.map((album) => album.id)));
 
     if (albumsToDisplay.length <= 0) {
         return (

--- a/src/components/albums/AlbumsControls.tsx
+++ b/src/components/albums/AlbumsControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { ActionIcon, Flex, Select, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Box, Flex, Select, Text, TextInput, useMantineTheme } from "@mantine/core";
 import { IconSquareX } from "@tabler/icons";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
@@ -18,10 +18,10 @@ import CardControls from "../shared/CardControls";
 import FilterInstructions from "../shared/FilterInstructions";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import ShowCountLabel from "../shared/ShowCountLabel";
+import PlayMediaIdsButton from "../shared/PlayMediaIdsButton";
 
 const AlbumsControls: FC = () => {
     const dispatch = useAppDispatch();
-    const { colors } = useMantineTheme();
     const { CARD_FILTER_WIDTH, STYLE_LABEL_BESIDE_COMPONENT } = useAppConstants();
     const { data: allAlbums } = useGetAlbumsQuery();
     const { data: newAlbums } = useGetNewAlbumsQuery();
@@ -31,7 +31,7 @@ const AlbumsControls: FC = () => {
     const currentAlbumMediaId = useAppSelector(
         (state: RootState) => state.playback.current_album_media_id
     );
-    const { filteredAlbumCount } = useAppSelector((state: RootState) => state.internal.albums);
+    const { filteredAlbumMediaIds } = useAppSelector((state: RootState) => state.internal.albums);
 
     // TODO: Improve the alignment of these various controls. Currently there's a lot of hackery of
     //  the tops of components to get them to look OK.
@@ -87,12 +87,21 @@ const AlbumsControls: FC = () => {
                     supportedKeys={["title", "artist", "creator", "genre", "date"]}
                     examples={["favorite album", "squirrels artist:(the rods) date:2004"]}
                 />
+
+                <Box pl={15}>
+                    <PlayMediaIdsButton
+                        mediaIds={filteredAlbumMediaIds}
+                        tooltipLabel={`Replace Playlist with ${filteredAlbumMediaIds.length} filtered Albums (10 max)`}
+                        notificationLabel={`Playlist replaced with ${filteredAlbumMediaIds.length} filtered Albums`}
+                        maxToPlay={10}
+                    />
+                </Box>
             </Flex>
 
             <Flex gap={20} justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
                 {/* "Showing x of y albums" */}
                 <ShowCountLabel
-                    showing={filteredAlbumCount}
+                    showing={filteredAlbumMediaIds.length}
                     of={
                         activeCollection === "all"
                             ? allAlbums?.length || 0

--- a/src/components/artists/ArtistWall.tsx
+++ b/src/components/artists/ArtistWall.tsx
@@ -23,7 +23,7 @@ import {
     setArtistsScrollSelectedIntoView,
     setArtistsScrollToCurrentOnScreenEnter,
     setArtistsScrollToSelectedOnScreenEnter,
-    setFilteredArtistCount,
+    setFilteredArtistMediaIds,
 } from "../../app/store/internalSlice";
 import {
     setArtistsSelectedAlbum,
@@ -290,7 +290,7 @@ const ArtistWall: FC = () => {
                       return artist.title.toLowerCase().includes(filterValueLower);
                   });
 
-    dispatch(setFilteredArtistCount(artistsToDisplay.length));
+    dispatch(setFilteredArtistMediaIds(artistsToDisplay.map((artist) => artist.id)));
 
     if (artistsToDisplay.length <= 0) {
         return (

--- a/src/components/artists/ArtistsControls.tsx
+++ b/src/components/artists/ArtistsControls.tsx
@@ -5,7 +5,6 @@ import {
     Button,
     Flex,
     Select,
-    Text,
     TextInput,
     Tooltip,
     useMantineTheme,
@@ -32,7 +31,6 @@ import ShowCountLabel from "../shared/ShowCountLabel";
 
 const ArtistsControls: FC = () => {
     const dispatch = useAppDispatch();
-    const { colors } = useMantineTheme();
     const { CARD_FILTER_WIDTH, STYLE_LABEL_BESIDE_COMPONENT } = useAppConstants();
     const albumsByArtistName = useAppSelector(
         (state: RootState) => state.mediaGroups.albumsByArtistName
@@ -40,9 +38,8 @@ const ArtistsControls: FC = () => {
     const tracksByArtistName = useAppSelector(
         (state: RootState) => state.mediaGroups.tracksByArtistName
     );
-    const { scrollCurrentIntoView, scrollSelectedIntoView } = useAppSelector(
-        (state: RootState) => state.internal.artists
-    );
+    const { filteredArtistMediaIds, scrollCurrentIntoView, scrollSelectedIntoView } =
+        useAppSelector((state: RootState) => state.internal.artists);
     const { activeCollection, filterText, selectedAlbum, selectedArtist, selectedTrack } =
         useAppSelector((state: RootState) => state.userSettings.artists);
     const currentAlbumMediaId = useAppSelector(
@@ -53,7 +50,6 @@ const ArtistsControls: FC = () => {
     );
     const { data: allArtists } = useGetArtistsQuery();
     const { data: allTracks } = useGetTracksQuery();
-    const { filteredArtistCount } = useAppSelector((state: RootState) => state.internal.artists);
 
     // --------------------------------------------------------------------------------------------
 
@@ -223,7 +219,7 @@ const ArtistsControls: FC = () => {
             {/* "Showing x of y artists" */}
             <Flex justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
                 <ShowCountLabel
-                    showing={filteredArtistCount}
+                    showing={filteredArtistMediaIds.length}
                     of={allArtists?.length || 0}
                     type="artists"
                 />

--- a/src/components/favorites/FavoritesControls.tsx
+++ b/src/components/favorites/FavoritesControls.tsx
@@ -41,7 +41,7 @@ const FavoritesControls: FC = () => {
     );
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
     const { favorites } = useAppSelector((state: RootState) => state.favorites);
-    const { filteredFavoriteCount } = useAppSelector(
+    const { filteredFavoriteMediaIds } = useAppSelector(
         (state: RootState) => state.internal.favorites
     );
     const [playFavoriteAlbums] = usePlayFavoriteAlbumsMutation();
@@ -147,7 +147,7 @@ const FavoritesControls: FC = () => {
             <Flex gap={20} justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
                 {/* "Showing x of y favorites" */}
                 <ShowCountLabel
-                    showing={filteredFavoriteCount}
+                    showing={filteredFavoriteMediaIds.length}
                     of={favorites.length}
                     type="favorites"
                 />

--- a/src/components/favorites/FavoritesWall.tsx
+++ b/src/components/favorites/FavoritesWall.tsx
@@ -5,7 +5,7 @@ import { Album, Track } from "../../app/types";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { RootState } from "../../app/store/store";
 import { collectionFilter } from "../../app/utils";
-import { setFilteredFavoriteCount } from "../../app/store/internalSlice";
+import { setFilteredFavoriteMediaIds } from "../../app/store/internalSlice";
 import AlbumCard from "../albums/AlbumCard";
 import SadLabel from "../shared/SadLabel";
 import StylizedLabel from "../shared/StylizedLabel";
@@ -58,7 +58,7 @@ const FavoritesWall: FC = () => {
             "title"
         );
 
-        dispatch(setFilteredFavoriteCount(collectionToShow.length));
+        dispatch(setFilteredFavoriteMediaIds(collectionToShow.map((favorite) => favorite.id)));
 
         return collectionToShow.length > 0 ? (
             <Box className={dynamicClasses.favoritesWall}>
@@ -114,7 +114,10 @@ const FavoritesWall: FC = () => {
     );
 
     dispatch(
-        setFilteredFavoriteCount(filteredAlbumFavorites.length + filteredTrackFavorites.length)
+        setFilteredFavoriteMediaIds([
+            ...filteredAlbumFavorites.map((albumFavorite) => albumFavorite.id),
+            ...filteredTrackFavorites.map((trackFavorite) => trackFavorite.id),
+        ])
     );
 
     return (

--- a/src/components/playlist/PlaylistControls.tsx
+++ b/src/components/playlist/PlaylistControls.tsx
@@ -111,8 +111,15 @@ const PlaylistDuration: FC = () => {
             <Text size="xs" pr={10} color={colors.dark[2]} weight="bold">{`${secstoHms(
                 activePlaylistDuration
             )}s`}</Text>
-            <RingProgress size={40} sections={[{ value: completed, color: "blue" }]} />
-            <Text size="xs" color={colors.blue[5]} weight="bold">{`${completed.toFixed(0)}%`}</Text>
+
+            {!isNaN(completed) && (
+                <>
+                    <RingProgress size={40} sections={[{ value: completed, color: "blue" }]} />
+                    <Text size="xs" color={colors.blue[5]} weight="bold">{`${completed.toFixed(
+                        0
+                    )}%`}</Text>
+                </>
+            )}
         </Flex>
     );
 };

--- a/src/components/presets/PresetWall.tsx
+++ b/src/components/presets/PresetWall.tsx
@@ -3,7 +3,7 @@ import { Box, createStyles } from "@mantine/core";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { RootState } from "../../app/store/store";
-import { setFilteredPresetCount } from "../../app/store/internalSlice";
+import { setFilteredPresetIds } from "../../app/store/internalSlice";
 import PresetCard from "./PresetCard";
 import { collectionFilter } from "../../app/utils";
 
@@ -24,7 +24,7 @@ const PresetWall: FC = () => {
 
     const presetsToDisplay = collectionFilter(presets, filterText, "name");
 
-    dispatch(setFilteredPresetCount(presetsToDisplay.length));
+    dispatch(setFilteredPresetIds(presetsToDisplay.map((preset) => preset.id)));
 
     return (
         <Box className={dynamicClasses.presetsWall}>

--- a/src/components/presets/PresetsControls.tsx
+++ b/src/components/presets/PresetsControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { ActionIcon, Flex, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Flex, TextInput, useMantineTheme } from "@mantine/core";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import {
@@ -18,13 +18,12 @@ import ShowCountLabel from "../shared/ShowCountLabel";
 
 const PresetsControls: FC = () => {
     const dispatch = useAppDispatch();
-    const { colors } = useMantineTheme();
     const { CARD_FILTER_WIDTH, STYLE_LABEL_BESIDE_COMPONENT } = useAppConstants();
     const { presets } = useAppSelector((state: RootState) => state.presets);
     const { cardSize, cardGap, filterText, showDetails } = useAppSelector(
         (state: RootState) => state.userSettings.presets
     );
-    const { filteredPresetCount } = useAppSelector((state: RootState) => state.internal.presets);
+    const { filteredPresetIds } = useAppSelector((state: RootState) => state.internal.presets);
 
     return (
         <Flex gap={25} align="center">
@@ -61,7 +60,7 @@ const PresetsControls: FC = () => {
             <Flex gap={20} justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
                 {/* "Showing x of y presets" */}
                 <ShowCountLabel
-                    showing={filteredPresetCount}
+                    showing={filteredPresetIds.length}
                     of={presets?.length || 0}
                     type="presets"
                 />

--- a/src/components/shared/PlayMediaIdsButton.tsx
+++ b/src/components/shared/PlayMediaIdsButton.tsx
@@ -1,0 +1,58 @@
+import React, { FC } from "react";
+import { ActionIcon, Box, Tooltip, useMantineTheme } from "@mantine/core";
+
+import { MediaId } from "../../app/types";
+import { IconPlayerPlay } from "@tabler/icons";
+import { useSetPlaylistMediaIdsMutation } from "../../app/services/vibinPlaylist";
+import { showSuccessNotification } from "../../app/utils";
+import { useAppConstants } from "../../app/hooks/useAppConstants";
+import { useAppSelector } from "../../app/hooks";
+import { RootState } from "../../app/store/store";
+
+type PlayMediaIdsButtonProps = {
+    mediaIds: MediaId[];
+    tooltipLabel?: string;
+    notificationLabel?: string;
+    maxToPlay?: number;
+};
+
+const PlayMediaIdsButton: FC<PlayMediaIdsButtonProps> = ({
+    mediaIds,
+    tooltipLabel = "Replace Playlist with filtered results",
+    notificationLabel = "Playlist replaced with filtered results",
+    maxToPlay = 10,
+}) => {
+    const theme = useMantineTheme();
+    const [setPlaylistIds, setPlaylistIdsStatus] = useSetPlaylistMediaIdsMutation();
+    const currentSource = useAppSelector((state: RootState) => state.playback.current_audio_source);
+
+    const isLocalMedia = currentSource ? currentSource.class === "stream.media" : false;
+
+    return (
+        <Tooltip label={tooltipLabel} position="bottom">
+            <Box sx={{ alignSelf: "center" }}>
+                <ActionIcon
+                    variant="light"
+                    color={theme.primaryColor}
+                    disabled={
+                        !isLocalMedia ||
+                        mediaIds.length === 0 ||
+                        mediaIds.length > maxToPlay
+                    }
+                    onClick={() => {
+                        setPlaylistIds({ mediaIds });
+
+                        showSuccessNotification({
+                            title: "Playlist replaced",
+                            message: notificationLabel,
+                        });
+                    }}
+                >
+                    <IconPlayerPlay size="1rem" />
+                </ActionIcon>
+            </Box>
+        </Tooltip>
+    );
+};
+
+export default PlayMediaIdsButton;

--- a/src/components/tracks/TrackWall.tsx
+++ b/src/components/tracks/TrackWall.tsx
@@ -1,11 +1,11 @@
-import React, { FC, useEffect, useState } from "react";
-import { Box, Center, createStyles, Loader, Text } from "@mantine/core";
+import React, { FC, useEffect } from "react";
+import { Box, Center, createStyles } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 
 import type { RootState } from "../../app/store/store";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { useGetTracksQuery, useSearchLyricsMutation } from "../../app/services/vibinTracks";
-import { setFilteredTrackCount } from "../../app/store/internalSlice";
+import { setFilteredTrackMediaIds } from "../../app/store/internalSlice";
 import TrackCard from "./TrackCard";
 import SadLabel from "../shared/SadLabel";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
@@ -19,9 +19,6 @@ const TrackWall: FC = () => {
     const [debouncedFilterText] = useDebouncedValue(filterText, 250);
     const { cardSize, cardGap, lyricsSearchText } = useAppSelector(
         (state: RootState) => state.userSettings.tracks
-    );
-    const currentTrackMediaId = useAppSelector(
-        (state: RootState) => state.playback.current_track_media_id
     );
     const { data: allTracks, error, isLoading } = useGetTracksQuery();
     const [searchLyrics, { data: tracksMatchingLyrics }] = useSearchLyricsMutation();
@@ -72,7 +69,7 @@ const TrackWall: FC = () => {
 
     const tracksToDisplay = collectionFilter(tracksToFilter, debouncedFilterText, "title");
 
-    dispatch(setFilteredTrackCount(tracksToDisplay.length));
+    dispatch(setFilteredTrackMediaIds(tracksToDisplay.map((track) => track.id)));
 
     if (tracksToDisplay.length <= 0) {
         return (

--- a/src/components/tracks/TracksControls.tsx
+++ b/src/components/tracks/TracksControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect } from "react";
-import { ActionIcon, Flex, Text, TextInput, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Box, Flex, TextInput } from "@mantine/core";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import {
@@ -18,19 +18,19 @@ import FilterInstructions from "../shared/FilterInstructions";
 import { useDebouncedValue } from "@mantine/hooks";
 import { IconSquareX } from "@tabler/icons";
 import ShowCountLabel from "../shared/ShowCountLabel";
+import PlayMediaIdsButton from "../shared/PlayMediaIdsButton";
 
 const lyricsSearchFinder = new RegExp(/(lyrics?):(\([^)]+?\)|[^( ]+)/);
 const stripParens = new RegExp(/^\(?([^\)]+)\)?$/);
 
 const TracksControls: FC = () => {
     const dispatch = useAppDispatch();
-    const { colors } = useMantineTheme();
     const { CARD_FILTER_WIDTH, STYLE_LABEL_BESIDE_COMPONENT } = useAppConstants();
     const { data: allTracks } = useGetTracksQuery();
     const { cardSize, cardGap, filterText, showDetails } = useAppSelector(
         (state: RootState) => state.userSettings.tracks
     );
-    const { filteredTrackCount } = useAppSelector((state: RootState) => state.internal.tracks);
+    const { filteredTrackMediaIds } = useAppSelector((state: RootState) => state.internal.tracks);
     const [debouncedFilterText] = useDebouncedValue(filterText, 250);
 
     // If the filter text includes something like "lyric:(some lyric search)" then store
@@ -88,12 +88,21 @@ const TracksControls: FC = () => {
                         "lyrics retrieved by the Vibin backend."
                     }
                 />
+
+                <Box pl={15}>
+                    <PlayMediaIdsButton
+                        mediaIds={filteredTrackMediaIds}
+                        tooltipLabel={`Replace Playlist with ${filteredTrackMediaIds.length} filtered Tracks (100 max)`}
+                        notificationLabel={`Playlist replaced with ${filteredTrackMediaIds.length} filtered Tracks`}
+                        maxToPlay={100}
+                    />
+                </Box>
             </Flex>
 
             <Flex gap={20} justify="right" sx={{ flexGrow: 1, alignSelf: "flex-end" }}>
                 {/* "Showing x of y tracks" */}
                 <ShowCountLabel
-                    showing={filteredTrackCount}
+                    showing={filteredTrackMediaIds.length}
                     of={allTracks?.length || 0}
                     type="tracks"
                 />


### PR DESCRIPTION
* Added new `<PlayMediaIdsButton>` component
* Limited to 100 tracks and 10 albums
* Replaced all filter counts in app state with filter Ids