### PR TITLE
Change how to show current album/track/playlist-entry; other cleanup

### DIFF
--- a/src/app/store/userSettingsSlice.ts
+++ b/src/app/store/userSettingsSlice.ts
@@ -81,8 +81,8 @@ export type MediaViewMode = "art_focused" | "compact";
 export type ApplicationTheme = "light" | "dark";
 export type PlaylistViewMode = "simple" | "detailed";
 export type PlaylistEditorSortField = "name" | "created" | "updated";
-export type AlbumCollection = "all" | "new" | "current";
-export type ArtistCollection = "all" | "with_albums" | "current";
+export type AlbumCollection = "all" | "new";
+export type ArtistCollection = "all" | "with_albums";
 export type FavoriteCollection = "all" | "albums" | "tracks";
 
 export interface UserSettingsState {

--- a/src/components/albums/AlbumWall.tsx
+++ b/src/components/albums/AlbumWall.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from "react";
-import { Box, Center, createStyles, Loader, Stack, Text } from "@mantine/core";
+import React, { FC, useEffect, useRef } from "react";
+import { Box, Center, createStyles } from "@mantine/core";
 
 import { Album } from "../../app/types";
 import type { RootState } from "../../app/store/store";
@@ -12,10 +12,15 @@ import { setFilteredAlbumMediaIds } from "../../app/store/internalSlice";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import { collectionFilter } from "../../app/utils";
 
-const AlbumWall: FC = () => {
+type AlbumWallProps = {
+    onNewCurrentAlbumRef?: (ref: HTMLDivElement) => void;
+}
+
+const AlbumWall: FC<AlbumWallProps> = ({ onNewCurrentAlbumRef }) => {
     const dispatch = useAppDispatch();
     const { SCREEN_LOADING_PT } = useAppConstants();
     const filterText = useAppSelector((state: RootState) => state.userSettings.albums.filterText);
+    const currentAlbumRef = useRef<HTMLDivElement>(null);
     const { activeCollection, cardSize, cardGap } = useAppSelector(
         (state: RootState) => state.userSettings.albums
     );
@@ -33,6 +38,12 @@ const AlbumWall: FC = () => {
             paddingBottom: 15,
         },
     }))();
+
+    useEffect(() => {
+        if (onNewCurrentAlbumRef && currentAlbumRef && currentAlbumRef.current) {
+            onNewCurrentAlbumRef(currentAlbumRef.current);
+        }
+    }, [currentAlbumRef, onNewCurrentAlbumRef, currentAlbumMediaId]);
 
     if ((activeCollection === "all" && allIsLoading) || (activeCollection === "new" && newIsLoading)) {
         return (
@@ -86,9 +97,15 @@ const AlbumWall: FC = () => {
 
     return (
         <Box className={dynamicClasses.albumWall}>
-            {albumsToDisplay.map((album) => (
-                <AlbumCard key={album.id} album={album} />
-            ))}
+            {albumsToDisplay.map((album: Album) =>
+                album.id === currentAlbumMediaId ? (
+                    <Box ref={currentAlbumRef}>
+                        <AlbumCard key={album.id} album={album} />
+                    </Box>
+                ) : (
+                    <AlbumCard key={album.id} album={album} />
+                )
+            )}
         </Box>
     );
 };

--- a/src/components/albums/AlbumsControls.tsx
+++ b/src/components/albums/AlbumsControls.tsx
@@ -19,8 +19,13 @@ import FilterInstructions from "../shared/FilterInstructions";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import ShowCountLabel from "../shared/ShowCountLabel";
 import PlayMediaIdsButton from "../shared/PlayMediaIdsButton";
+import CurrentlyPlayingButton from "../shared/CurrentlyPlayingButton";
 
-const AlbumsControls: FC = () => {
+type AlbumsControlsProps = {
+    scrollToCurrent?: () => void;
+}
+
+const AlbumsControls: FC<AlbumsControlsProps> = ({ scrollToCurrent }) => {
     const dispatch = useAppDispatch();
     const { CARD_FILTER_WIDTH, STYLE_LABEL_BESIDE_COMPONENT } = useAppConstants();
     const { data: allAlbums } = useGetAlbumsQuery();
@@ -37,7 +42,7 @@ const AlbumsControls: FC = () => {
     //  the tops of components to get them to look OK.
 
     return (
-        <Flex gap={25} align="flex-end">
+        <Flex gap={25} align="center">
             {/* Active collection */}
             <Select
                 label="Show"
@@ -45,7 +50,6 @@ const AlbumsControls: FC = () => {
                 data={[
                     { value: "all", label: "All Albums" },
                     { value: "new", label: "New Albums" },
-                    { value: "current", label: "Currently Playing" },
                 ]}
                 onChange={(value) =>
                     value && dispatch(setAlbumsActiveCollection(value as AlbumCollection))
@@ -87,12 +91,16 @@ const AlbumsControls: FC = () => {
                     supportedKeys={["title", "artist", "creator", "genre", "date"]}
                     examples={["favorite album", "squirrels artist:(the rods) date:2004"]}
                 />
+            </Flex>
 
-                <Box pl={15}>
+            <Flex align="center" gap={10}>
+                <CurrentlyPlayingButton onClick={() => scrollToCurrent && scrollToCurrent()} />
+
+                <Box>
                     <PlayMediaIdsButton
                         mediaIds={filteredAlbumMediaIds}
-                        tooltipLabel={`Replace Playlist with ${filteredAlbumMediaIds.length} filtered Albums (10 max)`}
-                        notificationLabel={`Playlist replaced with ${filteredAlbumMediaIds.length} filtered Albums`}
+                        tooltipLabel={`Replace Playlist with ${filteredAlbumMediaIds.length.toLocaleString()} filtered Albums (10 max)`}
+                        notificationLabel={`Playlist replaced with ${filteredAlbumMediaIds.length.toLocaleString()} filtered Albums`}
                         maxToPlay={10}
                     />
                 </Box>

--- a/src/components/artists/ArtistWall.tsx
+++ b/src/components/artists/ArtistWall.tsx
@@ -271,24 +271,19 @@ const ArtistWall: FC = () => {
     // 3. What's currently playing, in which case limit the artist list to the selected artist
     //      (the ArtistsControls will have set this artist in application state).
 
-    const artistsToDisplay: Artist[] =
-        activeCollection === "current"
-            ? currentArtist
-                ? [currentArtist]
-                : []
-            : allArtists
-                  .filter((artist: Artist) => {
-                      return activeCollection === "all" || artistIdsWithAlbums.includes(artist.id);
-                  })
-                  .filter((artist: Artist) => {
-                      if (filterText === "") {
-                          return true;
-                      }
+    const artistsToDisplay: Artist[] = allArtists
+        .filter((artist: Artist) => {
+            return activeCollection === "all" || artistIdsWithAlbums.includes(artist.id);
+        })
+        .filter((artist: Artist) => {
+            if (filterText === "") {
+                return true;
+            }
 
-                      const filterValueLower = filterText.toLowerCase();
+            const filterValueLower = filterText.toLowerCase();
 
-                      return artist.title.toLowerCase().includes(filterValueLower);
-                  });
+            return artist.title.toLowerCase().includes(filterValueLower);
+        });
 
     dispatch(setFilteredArtistMediaIds(artistsToDisplay.map((artist) => artist.id)));
 

--- a/src/components/artists/ArtistsControls.tsx
+++ b/src/components/artists/ArtistsControls.tsx
@@ -26,8 +26,9 @@ import { RootState } from "../../app/store/store";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
 import { useGetArtistsQuery } from "../../app/services/vibinArtists";
 import { useGetTracksQuery } from "../../app/services/vibinTracks";
-import { IconSquareX } from "@tabler/icons";
+import { IconCurrentLocation, IconHandFinger, IconSquareX } from "@tabler/icons";
 import ShowCountLabel from "../shared/ShowCountLabel";
+import CurrentlyPlayingButton from "../shared/CurrentlyPlayingButton";
 
 const ArtistsControls: FC = () => {
     const dispatch = useAppDispatch();
@@ -109,19 +110,6 @@ const ArtistsControls: FC = () => {
         // currentTrackMediaId && emitNewSelection(currentTrackMediaId);
     }, [currentTrackMediaId, dispatch]);
 
-    /**
-     * If the currently-playing Track id changes and the Artists screen is in "current" mode, then
-     * automatically select the current artist, album and track.
-     *
-     * Reasoning: An album, track, etc, can be played from the Artists screen. When this happens,
-     * it seems reasonable to want to reflect the newly-playing media by selecting it in the UI.
-     */
-    useEffect(() => {
-        if (activeCollection === "current" && currentTrackMediaId) {
-            emitNewSelection(currentTrackMediaId);
-        }
-    }, [currentTrackMediaId, activeCollection, albumsByArtistName, tracksByArtistName]);
-
     // --------------------------------------------------------------------------------------------
 
     return (
@@ -134,11 +122,6 @@ const ArtistsControls: FC = () => {
                 data={[
                     { value: "all", label: "All Artists" },
                     { value: "with_albums", label: "Artists with Albums" },
-                    {
-                        value: "current",
-                        label: "Currently Playing",
-                        disabled: !currentTrackMediaId,
-                    },
                 ]}
                 onChange={onArtistCollectionChange}
                 styles={{
@@ -162,7 +145,6 @@ const ArtistsControls: FC = () => {
                         <IconSquareX size="1.3rem" style={{ display: "block", opacity: 0.5 }} />
                     </ActionIcon>
                 }
-                disabled={activeCollection === "current"}
                 onChange={(event) => {
                     dispatch(setArtistsFilterText(event.target.value));
 
@@ -179,40 +161,24 @@ const ArtistsControls: FC = () => {
                 }}
             />
 
-            <Flex gap={10}>
+            <Flex gap={5}>
                 {/* Scroll currently-playing items into view */}
-                <Tooltip label="Scroll currently-playing items into view">
-                    <Box>
-                        <Button
-                            compact
-                            size="xs"
-                            variant="light"
-                            color="yellow"
-                            disabled={!currentTrackMediaId}
-                            onClick={() => {
-                                dispatch(setArtistsFilterText(""));
-                                currentTrackMediaId && emitNewSelection(currentTrackMediaId);
-                                scrollCurrentIntoView();
-                            }}
-                        >
-                            Current
-                        </Button>
-                    </Box>
-                </Tooltip>
+                <CurrentlyPlayingButton
+                    onClick={() => {
+                        currentTrackMediaId && emitNewSelection(currentTrackMediaId);
+                        scrollCurrentIntoView();
+                    }}
+                />
 
                 {/* Scroll selected items into view */}
-                <Tooltip label="Scroll selected items into view">
-                    <Box>
-                        <Button
-                            compact
-                            size="xs"
-                            variant="light"
-                            disabled={!selectedArtist && !selectedAlbum && !selectedTrack}
-                            onClick={scrollSelectedIntoView}
-                        >
-                            Selected
-                        </Button>
-                    </Box>
+                <Tooltip label="Scroll selected items into view" position="bottom">
+                    <ActionIcon
+                        color="blue"
+                        disabled={!selectedArtist && !selectedAlbum && !selectedTrack}
+                        onClick={scrollSelectedIntoView}
+                    >
+                        <IconHandFinger size="1.2rem" />
+                    </ActionIcon>
                 </Tooltip>
             </Flex>
 

--- a/src/components/layout/AlbumsScreen.tsx
+++ b/src/components/layout/AlbumsScreen.tsx
@@ -1,21 +1,44 @@
-import React, { FC } from "react";
+import React, { FC, useCallback, useState } from "react";
 import { Box, Stack } from "@mantine/core";
 
+import { useAppDispatch } from "../../app/hooks";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
-import AlbumWall from "../albums/AlbumWall";
+import { setAlbumsActiveCollection, setAlbumsFilterText } from "../../app/store/userSettingsSlice";
 import AlbumsControls from "../albums/AlbumsControls";
+import AlbumWall from "../albums/AlbumWall";
 import ScreenHeader from "./ScreenHeader";
 
 const AlbumsScreen: FC = () => {
-    const { SCREEN_HEADER_HEIGHT } = useAppConstants();
+    const dispatch = useAppDispatch();
+    const { HEADER_HEIGHT, SCREEN_HEADER_HEIGHT } = useAppConstants();
+    const [currentAlbumRef, setCurrentAlbumRef] = useState<HTMLDivElement>();
+
+    /**
+     *
+     */
+    const scrollToCurrent = useCallback(() => {
+        dispatch(setAlbumsActiveCollection("all"));
+        dispatch(setAlbumsFilterText(""));
+
+        if (currentAlbumRef) {
+            const buffer = 10;
+
+            const currentAlbumTop =
+                currentAlbumRef.getBoundingClientRect().top +
+                window.scrollY -
+                (HEADER_HEIGHT + SCREEN_HEADER_HEIGHT + buffer);
+
+            window.scrollTo({ top: currentAlbumTop });
+        }
+    }, [currentAlbumRef]);
 
     return (
         <Stack spacing={0}>
             <ScreenHeader height={SCREEN_HEADER_HEIGHT}>
-                <AlbumsControls />
+                <AlbumsControls scrollToCurrent={scrollToCurrent} />
             </ScreenHeader>
             <Box pt={SCREEN_HEADER_HEIGHT}>
-                <AlbumWall />
+                <AlbumWall onNewCurrentAlbumRef={setCurrentAlbumRef} />
             </Box>
         </Stack>
     );

--- a/src/components/layout/StatusScreen.tsx
+++ b/src/components/layout/StatusScreen.tsx
@@ -56,6 +56,22 @@ const StatusScreen: FC = () => {
 
     return (
         <Stack>
+            {/* User settings ----------------------------------------------------------------- */}
+
+            <Paper pt={5} p={15} shadow="xs">
+                <Stack spacing={10}>
+                    <StylizedLabel color={colors.dark[3]}>user settings</StylizedLabel>
+
+                    <Checkbox
+                        checked={useImageBackground}
+                        label="Show art image background in Now Playing screens (dark mode only)"
+                        onClick={() =>
+                            dispatch(setApplicationUseImageBackground(!useImageBackground))
+                        }
+                    />
+                </Stack>
+            </Paper>
+
             {/* Web Application ---------------------------------------------------------------- */}
 
             <Paper pt={5} p={15} shadow="xs">
@@ -201,22 +217,6 @@ const StatusScreen: FC = () => {
                             </tbody>
                         </Table>
                     </Stack>
-                </Stack>
-            </Paper>
-
-            {/* User settings ----------------------------------------------------------------- */}
-
-            <Paper pt={5} p={15} shadow="xs">
-                <Stack spacing={10}>
-                    <StylizedLabel color={colors.dark[3]}>user settings</StylizedLabel>
-
-                    <Checkbox
-                        checked={useImageBackground}
-                        label="Show art image background in Now Playing screens (dark mode only)"
-                        onClick={() =>
-                            dispatch(setApplicationUseImageBackground(!useImageBackground))
-                        }
-                    />
                 </Stack>
             </Paper>
         </Stack>

--- a/src/components/layout/TracksScreen.tsx
+++ b/src/components/layout/TracksScreen.tsx
@@ -1,21 +1,43 @@
-import React, { FC } from "react";
+import React, { FC, useCallback, useState } from "react";
 import { Box, Stack } from "@mantine/core";
 
+import { useAppDispatch } from "../../app/hooks";
 import { useAppConstants } from "../../app/hooks/useAppConstants";
+import { setTracksFilterText } from "../../app/store/userSettingsSlice";
 import TracksControls from "../tracks/TracksControls";
 import TrackWall from "../tracks/TrackWall";
 import ScreenHeader from "./ScreenHeader";
 
 const TracksScreen: FC = () => {
-    const { SCREEN_HEADER_HEIGHT } = useAppConstants();
+    const dispatch = useAppDispatch();
+    const { HEADER_HEIGHT, SCREEN_HEADER_HEIGHT } = useAppConstants();
+    const [currentTrackRef, setCurrentTrackRef] = useState<HTMLDivElement>();
+
+    /**
+     *
+     */
+    const scrollToCurrent = useCallback(() => {
+        dispatch(setTracksFilterText(""));
+
+        if (currentTrackRef) {
+            const buffer = 10;
+
+            const currentTrackTop =
+                currentTrackRef.getBoundingClientRect().top +
+                window.scrollY -
+                (HEADER_HEIGHT + SCREEN_HEADER_HEIGHT + buffer);
+
+            window.scrollTo({ top: currentTrackTop });
+        }
+    }, [currentTrackRef]);
 
     return (
         <Stack spacing={0}>
             <ScreenHeader height={SCREEN_HEADER_HEIGHT}>
-                <TracksControls />
+                <TracksControls scrollToCurrent={scrollToCurrent} />
             </ScreenHeader>
             <Box pt={SCREEN_HEADER_HEIGHT}>
-                <TrackWall />
+                <TrackWall onNewCurrentTrackRef={setCurrentTrackRef} />
             </Box>
         </Stack>
     );

--- a/src/components/playlist/PlaylistControls.tsx
+++ b/src/components/playlist/PlaylistControls.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../app/services/vibinStoredPlaylists";
 import { RootState } from "../../app/store/store";
 import StoredPlaylistsEditor from "./StoredPlaylistsEditor";
+import CurrentlyPlayingButton from "../shared/CurrentlyPlayingButton";
 import {
     epochSecondsToStringRelative,
     hmsToSecs,
@@ -115,7 +116,7 @@ const PlaylistDuration: FC = () => {
             {!isNaN(completed) && (
                 <>
                     <RingProgress size={40} sections={[{ value: completed, color: "blue" }]} />
-                    <Text size="xs" color={colors.blue[5]} weight="bold">{`${completed.toFixed(
+                    <Text size="xs" color={colors.blue[5]} weight="bold" miw="1.80rem">{`${completed.toFixed(
                         0
                     )}%`}</Text>
                 </>
@@ -159,7 +160,11 @@ const PlaylistSelectItem = forwardRef<HTMLDivElement, PlaylistSelectItemProps>(
 
 // ------------------------------------------------------------------------------------------------
 
-const PlaylistControls: FC = () => {
+type PlaylistControlsProps = {
+    scrollToCurrent?: () => void;
+}
+
+const PlaylistControls: FC<PlaylistControlsProps> = ({ scrollToCurrent }) => {
     const { APP_MODAL_BLUR, RENDER_APP_BACKGROUND_IMAGE } = useAppConstants();
     const { colors } = useMantineTheme();
     const dispatch = useAppDispatch();
@@ -407,13 +412,14 @@ const PlaylistControls: FC = () => {
                     ]}
                 />
 
-                {/* Playlist duration */}
                 <PlaylistDuration />
+
+                <CurrentlyPlayingButton onClick={scrollToCurrent} />
             </Flex>
 
             {/* Inform the user if the current persisted playlist has changed */}
             {isPlaylistPersisted && !activeSyncedWithStore && (
-                <Tooltip label="Playlist has unsaved changes">
+                <Tooltip label="Playlist has unsaved changes" position="bottom">
                     <ThemeIcon color="yellow" size={20} radius={10}>
                         <IconExclamationMark size={17} stroke={2} color={colors.dark[7]} />
                     </ThemeIcon>

--- a/src/components/shared/CurrentlyPlayingButton.tsx
+++ b/src/components/shared/CurrentlyPlayingButton.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from "react";
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { IconCurrentLocation } from "@tabler/icons";
+
+import { RootState } from "../../app/store/store";
+import { useAppSelector } from "../../app/hooks";
+
+type CurrentlyPlayingButtonProps = {
+    onClick?: () => void;
+}
+
+const CurrentlyPlayingButton: FC<CurrentlyPlayingButtonProps> = ({ onClick }) => {
+    const currentTrackMediaId = useAppSelector(
+        (state: RootState) => state.playback.current_track_media_id
+    );
+
+    return (
+        <Tooltip label="Scroll current Track into view" position="bottom">
+            <ActionIcon color="yellow" disabled={!currentTrackMediaId} onClick={() => onClick && onClick()}>
+                <IconCurrentLocation size="1.2rem" />
+            </ActionIcon>
+        </Tooltip>
+    );
+};
+
+export default CurrentlyPlayingButton;

--- a/src/components/tracks/TracksControls.tsx
+++ b/src/components/tracks/TracksControls.tsx
@@ -19,11 +19,16 @@ import { useDebouncedValue } from "@mantine/hooks";
 import { IconSquareX } from "@tabler/icons";
 import ShowCountLabel from "../shared/ShowCountLabel";
 import PlayMediaIdsButton from "../shared/PlayMediaIdsButton";
+import CurrentlyPlayingButton from "../shared/CurrentlyPlayingButton";
 
 const lyricsSearchFinder = new RegExp(/(lyrics?):(\([^)]+?\)|[^( ]+)/);
 const stripParens = new RegExp(/^\(?([^\)]+)\)?$/);
 
-const TracksControls: FC = () => {
+type TracksControlsProps = {
+    scrollToCurrent?: () => void;
+}
+
+const TracksControls: FC<TracksControlsProps> = ({ scrollToCurrent }) => {
     const dispatch = useAppDispatch();
     const { CARD_FILTER_WIDTH, STYLE_LABEL_BESIDE_COMPONENT } = useAppConstants();
     const { data: allTracks } = useGetTracksQuery();
@@ -88,12 +93,16 @@ const TracksControls: FC = () => {
                         "lyrics retrieved by the Vibin backend."
                     }
                 />
+            </Flex>
+
+            <Flex>
+                <CurrentlyPlayingButton onClick={() => scrollToCurrent && scrollToCurrent()} />
 
                 <Box pl={15}>
                     <PlayMediaIdsButton
                         mediaIds={filteredTrackMediaIds}
-                        tooltipLabel={`Replace Playlist with ${filteredTrackMediaIds.length} filtered Tracks (100 max)`}
-                        notificationLabel={`Playlist replaced with ${filteredTrackMediaIds.length} filtered Tracks`}
+                        tooltipLabel={`Replace Playlist with ${filteredTrackMediaIds.length.toLocaleString()} filtered Tracks (100 max)`}
+                        notificationLabel={`Playlist replaced with ${filteredTrackMediaIds.length.toLocaleString()} filtered Tracks`}
                         maxToPlay={100}
                     />
                 </Box>


### PR DESCRIPTION
* Remove "current" option from Artist and Playlist selection dropdowns
* Add `<CurrentlyPlayingButton>` to trigger "show current' behavior
* Use `<CurrentlyPlayingButton>` in Album, Track, and Playlist screens
* Move user settings to top of `<StatusScreen>`