### PR TITLE
Make various UX improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,11 +75,11 @@ export default function App() {
                 },
                 {
                     path: "*",
-                    element: <Navigate to="/ui/albums" replace />,
+                    element: <Navigate to="/ui/playlist" replace />,
                 },
                 {
                     index: true,
-                    element: <Navigate to="/ui/albums" replace />,
+                    element: <Navigate to="/ui/playlist" replace />,
                 },
             ],
         },

--- a/src/components/albums/AlbumsControls.tsx
+++ b/src/components/albums/AlbumsControls.tsx
@@ -96,6 +96,7 @@ const AlbumsControls: FC<AlbumsControlsProps> = ({ scrollToCurrent }) => {
             <Flex align="center" gap={10}>
                 <CurrentlyPlayingButton
                     disabled={activeCollection !== "all" || filterText !== ""}
+                    tooltipLabel="Show currently playing Album"
                     onClick={() => scrollToCurrent && scrollToCurrent()}
                 />
 

--- a/src/components/artists/ArtistsControls.tsx
+++ b/src/components/artists/ArtistsControls.tsx
@@ -164,6 +164,7 @@ const ArtistsControls: FC = () => {
             <Flex gap={5}>
                 {/* Scroll currently-playing items into view */}
                 <CurrentlyPlayingButton
+                    tooltipLabel="Show currently playing"
                     onClick={() => {
                         currentTrackMediaId && emitNewSelection(currentTrackMediaId);
                         scrollCurrentIntoView();

--- a/src/components/favorites/FavoritesControls.tsx
+++ b/src/components/favorites/FavoritesControls.tsx
@@ -129,9 +129,9 @@ const FavoritesControls: FC = () => {
                     ...filteredFavoriteMediaIds.albums.slice(0, 10),
                     ...filteredFavoriteMediaIds.tracks.slice(0, 100),
                 ]}
-                tooltipLabel="Replace Playlist with visible Favorites"
-                menuItemLabel="Replace Playlist with visible Favorites"
-                notificationLabel={`Playlist replaced with visible Favorites`}
+                tooltipLabel="Replace Playlist with filtered Favorites"
+                menuItemLabel="Replace Playlist with filtered Favorites"
+                notificationLabel={`Playlist replaced with filtered Favorites`}
                 maxToPlay={100}
             />
 

--- a/src/components/managers/BackgroundImageManager.tsx
+++ b/src/components/managers/BackgroundImageManager.tsx
@@ -1,0 +1,35 @@
+import React, { FC, useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import type { RootState } from "../../app/store/store";
+import { useAppSelector } from "../../app/hooks";
+import { setCurrentlyPlayingArtUrl } from "../../app/store/internalSlice";
+
+const BackgroundImageManager: FC = () => {
+    const dispatch = useDispatch();
+    const playlist = useAppSelector((state: RootState) => state.playlist);
+    const trackById = useAppSelector((state: RootState) => state.mediaGroups.trackById);
+    const currentTrackId = useAppSelector(
+        (state: RootState) => state.playback.current_track_media_id
+    );
+
+    /**
+     * Set the background image URL. This will change whenever the current track changes. If
+     * there's no current track then attempt to fall back on the current playlist entry.
+     */
+    useEffect(() => {
+        if (currentTrackId && trackById[currentTrackId]) {
+            dispatch(setCurrentlyPlayingArtUrl(trackById[currentTrackId].album_art_uri));
+        } else if (playlist && playlist.entries && playlist.current_track_index) {
+            dispatch(
+                setCurrentlyPlayingArtUrl(
+                    playlist.entries[playlist.current_track_index]?.albumArtURI
+                )
+            );
+        }
+    }, [dispatch, currentTrackId, trackById, playlist]);
+
+    return null;
+};
+
+export default BackgroundImageManager;

--- a/src/components/shared/CurrentlyPlayingButton.tsx
+++ b/src/components/shared/CurrentlyPlayingButton.tsx
@@ -7,16 +7,21 @@ import { useAppSelector } from "../../app/hooks";
 
 type CurrentlyPlayingButtonProps = {
     disabled?: boolean;
+    tooltipLabel?: string;
     onClick?: () => void;
 };
 
-const CurrentlyPlayingButton: FC<CurrentlyPlayingButtonProps> = ({ disabled = false, onClick }) => {
+const CurrentlyPlayingButton: FC<CurrentlyPlayingButtonProps> = ({
+    disabled = false,
+    tooltipLabel = "Show current item",
+    onClick,
+}) => {
     const currentTrackMediaId = useAppSelector(
         (state: RootState) => state.playback.current_track_media_id
     );
 
     return (
-        <Tooltip label="Scroll current Track into view" position="bottom">
+        <Tooltip label={tooltipLabel} position="bottom">
             <Box>
                 <ActionIcon
                     color="yellow"

--- a/src/components/tracks/TracksControls.tsx
+++ b/src/components/tracks/TracksControls.tsx
@@ -98,6 +98,7 @@ const TracksControls: FC<TracksControlsProps> = ({ scrollToCurrent }) => {
             <Flex>
                 <CurrentlyPlayingButton
                     disabled={filterText !== ""}
+                    tooltipLabel="Show currently playing Track"
                     onClick={() => scrollToCurrent && scrollToCurrent()}
                 />
 


### PR DESCRIPTION
* Change default landing screen to Playlist (changed from Albums).
* Allow for `<CurrentlyPlayingButton>` to accept a tooltip label.
* Migrate background image logic to `<BackgroundImageManager>` and only enable it for Current Track and Playlist screens.
* In Playlist, clicking the current track now pauses/resumes playback. Also changes the play icon to a pause icon where appropriate.