### PR TITLE
Disable the Playlist auto-follow feature when the Playlist is modified

### DIFF
--- a/src/components/layout/PlaylistScreen.tsx
+++ b/src/components/layout/PlaylistScreen.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { RootState, store } from "../../app/store/store";
 import { useAppGlobals } from "../../app/hooks/useAppGlobals";
 import { setPlaylistScrollPos } from "../../app/store/internalSlice";
+import { setPlaylistFollowCurrentlyPlaying } from "../../app/store/userSettingsSlice";
 import Playlist from "../playlist/Playlist";
 import PlaylistControls from "../playlist/PlaylistControls";
 import ScreenHeader from "./ScreenHeader";
@@ -126,7 +127,16 @@ const PlaylistScreen: FC = () => {
                     onScrollPositionChange={throttledPlaylistPosChange}
                     offsetScrollbars
                 >
-                    <Playlist onNewCurrentEntryRef={setCurrentEntryRef} />
+                    <Playlist
+                        onNewCurrentEntryRef={setCurrentEntryRef}
+                        onPlaylistModified={() =>
+                            // When the Playlist gets modified, disabling the follow feature avoids
+                            // weird-feeling UI updates while modifying. Although this requires the
+                            // user to be aware that they might want to re-enable Follow once
+                            // finished modifying.
+                            dispatch(setPlaylistFollowCurrentlyPlaying(false))
+                        }
+                    />
                 </ScrollArea>
             </Box>
         </Stack>

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -130,6 +130,7 @@ const useStyles = createStyles((theme) => ({
 
 type PlaylistProps = {
     onNewCurrentEntryRef?: (ref: HTMLDivElement) => void;
+    onPlaylistModified?: () => void;
 }
 
 /**
@@ -142,7 +143,7 @@ type PlaylistProps = {
  * @constructor
  */
 
-const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef }) => {
+const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef, onPlaylistModified }) => {
     const { colors } = useMantineTheme();
     const { CURRENTLY_PLAYING_COLOR } = useAppGlobals();
     const playlist = useAppSelector((state: RootState) => state.playlist);
@@ -459,6 +460,7 @@ const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef }) => {
                                         tooltipLabel="Remove from Playlist"
                                         onClick={() => {
                                             deletePlaylistId({ playlistId: entry.id });
+                                            onPlaylistModified && onPlaylistModified();
 
                                             showSuccessNotification({
                                                 title: "Entry removed from Playlist",
@@ -493,6 +495,7 @@ const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef }) => {
         <>
             {activatingStoredPlaylist && <Overlay opacity={0.5} color="#000000" radius={5} />}
             <DragDropContext
+                onDragStart={() => onPlaylistModified && onPlaylistModified()}
                 onDragEnd={({ draggableId, source, destination }) => {
                     if (destination) {
                         if (source.index === destination.index) {


### PR DESCRIPTION
This avoids weird-feeling UI updates while modifying, although it requires the user to be aware that they might want to re-enable Follow once finished modifying.