### PR TITLE
Fall back on `currentPlaybackTrack` when determining bg image url

### DIFF
--- a/src/app/store/playbackSlice.ts
+++ b/src/app/store/playbackSlice.ts
@@ -68,6 +68,11 @@ export type ShuffleState = "off" | "all";
 
 // TODO: Rename top-level state fields from snake_case to camelCase.
 
+// TODO: Clarify current_track_media_id vs current_track. The former is valid for local media and
+//  is the source of truth for the playing track id. current_track however is also populated by
+//  other sources like AirPlay. It would be good to either merge these, or be clearer about when
+//  to use what.
+
 export interface PlaybackState {
     play_status: PlayStatus | undefined;
     active_transport_actions: TransportAction[];

--- a/src/components/managers/BackgroundImageManager.tsx
+++ b/src/components/managers/BackgroundImageManager.tsx
@@ -12,22 +12,33 @@ const BackgroundImageManager: FC = () => {
     const currentTrackId = useAppSelector(
         (state: RootState) => state.playback.current_track_media_id
     );
+    const currentPlaybackTrack = useAppSelector((state: RootState) => state.playback.current_track);
 
     /**
      * Set the background image URL. This will change whenever the current track changes. If
-     * there's no current track then attempt to fall back on the current playlist entry.
+     * there's no current track then attempt to fall back on the current playlist entry and finally
+     * the currentPlaybackTrack (e.g. AirPlay).
+     *
+     * The currentlyPlayingArtUrl is used by <RootLayout> to render the background image div.
      */
     useEffect(() => {
         if (currentTrackId && trackById[currentTrackId]) {
             dispatch(setCurrentlyPlayingArtUrl(trackById[currentTrackId].album_art_uri));
-        } else if (playlist && playlist.entries && playlist.current_track_index !== undefined) {
+        } else if (
+            playlist &&
+            playlist.entries &&
+            playlist.current_track_index !== undefined &&
+            playlist.current_track_index !== -1
+        ) {
             dispatch(
                 setCurrentlyPlayingArtUrl(
                     playlist.entries[playlist.current_track_index]?.albumArtURI
                 )
             );
+        } else if (currentPlaybackTrack?.art_url) {
+            dispatch(setCurrentlyPlayingArtUrl(currentPlaybackTrack.art_url));
         }
-    }, [dispatch, currentTrackId, trackById, playlist]);
+    }, [dispatch, currentTrackId, trackById, playlist, currentPlaybackTrack]);
 
     return null;
 };


### PR DESCRIPTION
This adds background support for sources which don't involve local media or the playlist, such as AirPlay.