### PR TITLE
Experiment to see if custom fonts can be loaded sooner

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import reportWebVitals from "./reportWebVitals";
 
 import { store } from "./app/store/store";
 import App from "./App";
+import CustomFonts from "./components/customFonts/CustomFonts";
 import "./index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
@@ -12,6 +13,7 @@ const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 root.render(
     <React.StrictMode>
         <Provider store={store}>
+            <CustomFonts />
             <App />
         </Provider>
     </React.StrictMode>


### PR DESCRIPTION
When a new device accesses the UI for the first time, the UI can be rendered with Times New Roman while it waits for the album/track/etc lists to be retrieved. It would be nice if the custom fonts could be loaded sooner. This is just a quick experiment to see if it helps.