### PR TITLE
Detect dev vs. prod when determining websocket port; increase nav width

### DIFF
--- a/src/app/hooks/useAppGlobals.ts
+++ b/src/app/hooks/useAppGlobals.ts
@@ -47,7 +47,7 @@ export const useAppGlobals = () => {
         CURRENTLY_PLAYING_COLOR: theme.colors.yellow[4],
         HEADER_HEIGHT: 60,
         LARGE_SCREEN: largeScreen,
-        NAVBAR_WIDTH: largeScreen === false ? 185 : 210,
+        NAVBAR_WIDTH: largeScreen === false ? 190 : 210,
         RENDER_APP_BACKGROUND_IMAGE: renderAppBackgroundImage,
         SCREEN_LOADING_PT: 25,
         SCREEN_HEADER_HEIGHT: 70,

--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -23,6 +23,7 @@ import {
     TransportAction,
 } from "../store/playbackSlice";
 import { WEBSOCKET_RECONNECT_DELAY } from "../constants";
+import { isDev } from "../utils";
 import { setWebsocketClientId, setWebsocketStatus } from "../store/internalSlice";
 import { setCurrentTrackIndex, setEntries } from "../store/playlistSlice";
 import { setPresetsState, PresetsState } from "../store/presetsSlice";
@@ -384,7 +385,11 @@ export const vibinWebsocket = createApi({
             ) {
                 const connectToVibinServer = async () => {
                     dispatch(setWebsocketStatus("connecting"));
-                    const ws = new WebSocket(`ws://${window.location.hostname}:7669/ws`);
+
+                    // NOTE: Development assumes there's a vibin server running on port 7669
+                    const ws = new WebSocket(
+                        `ws://${window.location.hostname}:${isDev ? 7669 : window.location.port}/ws`
+                    );
 
                     const listener = messageHandler(updateCachedData, getState, dispatch);
 

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -10,6 +10,8 @@ dayjs.extend(relativeTime);
 
 // TODO: Write tests
 
+export const isDev = process.env.NODE_ENV === "development";
+
 /**
  *
  * TODO: This (ensuring consistent data types for the same concept) would ideally be done in the


### PR DESCRIPTION
* Production should use the same port for the websocket as it does for the application. Development mode should instead look to a locally- running vibin server on port 7669.
* The "small screen" nav bar width was too narrow for Firefox, which resulted in "Current Track" being wrapped.