### PR TITLE
Show Playlist screen when streamer is off; add follow icon

### DIFF
--- a/src/components/layout/PlaylistScreen.tsx
+++ b/src/components/layout/PlaylistScreen.tsx
@@ -112,9 +112,7 @@ const PlaylistScreen: FC = () => {
 
     // --------------------------------------------------------------------------------------------
 
-    return streamerPower === "off" ? (
-        <StandbyMode />
-    ) : (
+    return (
         <Stack spacing={0}>
             <ScreenHeader height={SCREEN_HEADER_HEIGHT} noBackground={RENDER_APP_BACKGROUND_IMAGE}>
                 <PlaylistControls scrollToCurrent={scrollToCurrent} />

--- a/src/components/playlist/PlaylistEntryActionsButton.tsx
+++ b/src/components/playlist/PlaylistEntryActionsButton.tsx
@@ -173,6 +173,7 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                         <Menu.Label>Playlist</Menu.Label>
 
                         <Menu.Item
+                            disabled={isStreamerOff}
                             icon={<IconArrowBarToUp size={14} />}
                             onClick={() => {
                                 moveEntry({
@@ -191,6 +192,7 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                         </Menu.Item>
 
                         <Menu.Item
+                            disabled={isStreamerOff}
                             icon={
                                 <IconPlayerPlay
                                     size={14}
@@ -213,7 +215,7 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                         </Menu.Item>
 
                         <Menu.Item
-                            disabled={!currentlyPlayingIndex}
+                            disabled={isStreamerOff || !currentlyPlayingIndex}
                             icon={<IconCornerDownRightDouble size={14} />}
                             onClick={() => {
                                 if (!currentlyPlayingIndex) {
@@ -238,6 +240,7 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                         </Menu.Item>
 
                         <Menu.Item
+                            disabled={isStreamerOff}
                             icon={<IconArrowBarToDown size={12} />}
                             onClick={() => {
                                 moveEntry({
@@ -256,6 +259,7 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
                         </Menu.Item>
 
                         <Menu.Item
+                            disabled={isStreamerOff}
                             icon={<IconTrash size={14} />}
                             onClick={() => {
                                 deletePlaylistId({ playlistId: entry.id });


### PR DESCRIPTION
* `<PlaylistScreen>` used to be disabled when the streamer was in standby mode. This PR instead shows the playlist screen, but disables the ability to modify the playlist; and turns the streamer on when a new playlist is selected from the dropdown.
* The "Follow" checkbox is replaced with `<FollowCurrentlyPlayingToggle>`.