### PR TITLE
Clean up build warnings

### DIFF
--- a/src/app/hooks/useAppGlobals.ts
+++ b/src/app/hooks/useAppGlobals.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { useMantineTheme } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 

--- a/src/app/hooks/useInterval.ts
+++ b/src/app/hooks/useInterval.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import type { TypedUseSelectorHook } from "react-redux";
 

--- a/src/app/hooks/useMediaGroupings.ts
+++ b/src/app/hooks/useMediaGroupings.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useReducer, useState } from "react";
+import { useEffect, useMemo, useReducer, useState } from "react";
 
 import { Album, Artist, Track } from "../types";
 import { useAppDispatch } from "./useInterval";
@@ -64,13 +64,10 @@ const localReducer = (state: LocalState, action: LocalAction): LocalState => {
 export const useMediaGroupings = () => {
     const [state, localDispatch] = useReducer(localReducer, { computing: [] });
     const dispatch = useAppDispatch();
-    const { data: allAlbums, error: albumsError, isSuccess: albumsIsSuccess } = useGetAlbumsQuery();
-    const {
-        data: allArtists,
-        error: artistsError,
-        isSuccess: artistsIsSuccess,
-    } = useGetArtistsQuery();
-    const { data: allTracks, error: tracksError, isSuccess: tracksIsSuccess } = useGetTracksQuery();
+    // TODO: Handle error states from API requests
+    const { data: allAlbums } = useGetAlbumsQuery();
+    const { data: allArtists } = useGetArtistsQuery();
+    const { data: allTracks } = useGetTracksQuery();
     const [albumsByArtistName, setAlbumsByArtistName] = useState<Record<string, Album[]>>({});
     const [albumById, setAlbumById] = useState<Record<string, Album>>({});
     const [artistByName, setArtistByName] = useState<Record<string, Artist>>({});

--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -22,7 +22,7 @@ import {
     ShuffleState,
     TransportAction,
 } from "../store/playbackSlice";
-import { isDev, WEBSOCKET_RECONNECT_DELAY, WEBSOCKET_URL } from "../constants";
+import { WEBSOCKET_RECONNECT_DELAY, WEBSOCKET_URL } from "../constants";
 import { setWebsocketClientId, setWebsocketStatus } from "../store/internalSlice";
 import { setCurrentTrackIndex, setEntries } from "../store/playlistSlice";
 import { setPresetsState, PresetsState } from "../store/presetsSlice";

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 import { showNotification } from "@mantine/notifications";
 import { IconCheck, IconX } from "@tabler/icons";
 import get from "lodash/get";

--- a/src/components/features/albums/AlbumArt.tsx
+++ b/src/components/features/albums/AlbumArt.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { Box, createStyles, Flex, Image, useMantineTheme } from "@mantine/core";
+import { Box, createStyles, Flex, Image } from "@mantine/core";
 import { FloatingPosition } from "@mantine/core/lib/Floating/types";
 import { IconPlayerPlay } from "@tabler/icons";
 

--- a/src/components/features/albums/AlbumTracks.tsx
+++ b/src/components/features/albums/AlbumTracks.tsx
@@ -35,7 +35,7 @@ type AlbumTracksProps = {
 };
 
 const AlbumTracks: FC<AlbumTracksProps> = ({ album }) => {
-    const { data: albumTracks, error, isLoading } = useGetAlbumTracksQuery(album.id);
+    const { data: albumTracks, isLoading } = useGetAlbumTracksQuery(album.id);
     const { classes } = useStyles();
     const [actionsMenuOpenFor, setActionsMenuOpenFor] = useState<string | undefined>(undefined);
 

--- a/src/components/features/albums/AppendToPlaylistButton.tsx
+++ b/src/components/features/albums/AppendToPlaylistButton.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { Box, createStyles, Tooltip } from "@mantine/core";
-import { showNotification, updateNotification } from "@mantine/notifications";
+import { updateNotification } from "@mantine/notifications";
 import { IconCheck, IconExclamationMark, IconPlaylistAdd } from "@tabler/icons";
 
 import { Album, Track } from "../../../app/types";

--- a/src/components/features/artists/ArtistsControls.tsx
+++ b/src/components/features/artists/ArtistsControls.tsx
@@ -96,7 +96,7 @@ const ArtistsControls: FC = () => {
         }
 
         // currentTrackMediaId && emitNewSelection(currentTrackMediaId);
-    }, [currentTrackMediaId, dispatch]);
+    }, [dispatch]);
 
     // --------------------------------------------------------------------------------------------
 

--- a/src/components/features/currentTrack/TrackLinks.tsx
+++ b/src/components/features/currentTrack/TrackLinks.tsx
@@ -75,7 +75,7 @@ type TrackLinksProps = {
 };
 
 const TrackLinks: FC<TrackLinksProps> = ({ trackId, artist, album, title }) => {
-    const { data, error, isFetching } = useGetLinksQuery({ trackId, artist, album, title, allTypes: true });
+    const { data, isFetching } = useGetLinksQuery({ trackId, artist, album, title, allTypes: true });
 
     if (isFetching) {
         return <LoadingDataMessage message="Retrieving links..." />;

--- a/src/components/features/currentTrack/TrackLyrics.tsx
+++ b/src/components/features/currentTrack/TrackLyrics.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { Box, Button, Center, createStyles, Flex, Highlight, Stack, Text } from "@mantine/core";
+import { Box, Button, createStyles, Flex, Highlight, Stack, Text } from "@mantine/core";
 
 import {
     LyricChunk,
@@ -29,7 +29,7 @@ const TrackLyrics: FC<TrackLyricsProps> = ({ trackId, artist, title }) => {
     const [maxLineWidth, setMaxLineWidth] = useState<number>(0);
     const [showInvalidLyrics, setShowInvalidLyrics] = useState<boolean>(false);
     const { lyricsSearchText } = useAppSelector((state: RootState) => state.userSettings.tracks);
-    const [validateLyrics, validateLyricsStatus] = useLazyValidateLyricsQuery();
+    const [validateLyrics] = useLazyValidateLyricsQuery();
     const [getLyrics, getLyricsStatus] = useLazyGetLyricsQuery();
 
     const { classes: dynamicClasses } = createStyles((theme) => ({

--- a/src/components/features/playlist/Playlist.tsx
+++ b/src/components/features/playlist/Playlist.tsx
@@ -251,7 +251,7 @@ const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef, onPlaylistModified 
         if (onNewCurrentEntryRef && currentEntryRef && currentEntryRef.current) {
             onNewCurrentEntryRef(currentEntryRef.current);
         }
-    }, [currentEntryRef.current, onNewCurrentEntryRef, playlist.current_track_index]);
+    }, [currentEntryRef, onNewCurrentEntryRef, playlist.current_track_index]);
 
     if (playStatus === "not_ready") {
         return <StandbyMode />;

--- a/src/components/features/playlist/PlaylistControls.tsx
+++ b/src/components/features/playlist/PlaylistControls.tsx
@@ -183,7 +183,7 @@ const PlaylistControls: FC<PlaylistControlsProps> = ({ scrollToCurrent }) => {
     } = useAppSelector((state: RootState) => state.storedPlaylists);
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
     const { current_track_index } = useAppSelector((state: RootState) => state.playlist);
-    const [togglePower, togglePowerStatus] = useLazyPowerToggleQuery();
+    const [togglePower] = useLazyPowerToggleQuery();
     const [activeStoredPlaylistName, setActiveStoredPlaylistName] = useState<string | undefined>();
     const [activateStoredPlaylistId, activatePlaylistStatus] = useLazyActivateStoredPlaylistQuery();
     const [storePlaylist, storePlaylistStatus] = useLazyStoreCurrentPlaylistQuery();

--- a/src/components/features/playlist/PlaylistEntryActionsButton.tsx
+++ b/src/components/features/playlist/PlaylistEntryActionsButton.tsx
@@ -18,7 +18,7 @@ import {
     IconWaveSine,
 } from "@tabler/icons";
 
-import { PlaylistEntry, Track } from "../../../app/types";
+import { PlaylistEntry } from "../../../app/types";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/useInterval";
 import { RootState } from "../../../app/store/store";
 import {
@@ -104,8 +104,8 @@ const PlaylistEntryActionsButton: FC<PlaylistEntryActionsButtonProps> = ({
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
     const [moveEntry, moveEntryStatus] = useMovePlaylistEntryIdMutation();
     const [deletePlaylistId, deleteStatus] = useDeletePlaylistEntryIdMutation();
-    const [addFavorite, addFavoriteStatus] = useAddFavoriteMutation();
-    const [deleteFavorite, deleteFavoriteStatus] = useDeleteFavoriteMutation();
+    const [addFavorite] = useAddFavoriteMutation();
+    const [deleteFavorite] = useDeleteFavoriteMutation();
     const [playPlaylistId, playStatus] = usePlayPlaylistEntryIdMutation();
     const { favorites } = useAppSelector((state: RootState) => state.favorites);
     const { albumById, artistByName, trackById } = useAppSelector(

--- a/src/components/features/tracks/TrackArt.tsx
+++ b/src/components/features/tracks/TrackArt.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { Box, Center, createStyles, Flex, Image, Text, useMantineTheme } from "@mantine/core";
+import { Box, createStyles, Flex, Image } from "@mantine/core";
 import { IconPlayerPlay } from "@tabler/icons";
 
 import { Track } from "../../../app/types";

--- a/src/components/features/tracks/TracksControls.tsx
+++ b/src/components/features/tracks/TracksControls.tsx
@@ -24,7 +24,7 @@ import CurrentlyPlayingButton from "../../shared/buttons/CurrentlyPlayingButton"
 import FollowCurrentlyPlayingToggle from "../../shared/buttons/FollowCurrentlyPlayingToggle";
 
 const lyricsSearchFinder = new RegExp(/(lyrics?):(\([^)]+?\)|[^( ]+)/);
-const stripParens = new RegExp(/^\(?([^\)]+)\)?$/);
+const stripParens = new RegExp(/^\(?([^)]+)\)?$/);
 
 type TracksControlsProps = {
     scrollToCurrent?: () => void;

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -24,11 +24,7 @@ import WelcomeMessage from "../app/WelcomeMessage";
 import { RootState } from "../../app/store/store";
 import { useAppDispatch, useAppSelector } from "../../app/hooks/useInterval";
 import { useAppGlobals } from "../../app/hooks/useAppGlobals";
-import {
-    setCurrentlyPlayingArtUrl,
-    setCurrentScreen,
-    setShowCurrentTrackLyrics,
-} from "../../app/store/internalSlice";
+import { setCurrentScreen, setShowCurrentTrackLyrics } from "../../app/store/internalSlice";
 import { setApplicationHaveShownWelcomeMessage } from "../../app/store/userSettingsSlice";
 
 const useStyles = createStyles((theme) => ({
@@ -71,7 +67,7 @@ const RootLayout: FC = () => {
     );
 
     const screenName = (): string | undefined => {
-        const screenNameMatch = location.pathname.match(new RegExp(`^${APP_URL_PREFIX}\/([^\/]+)`));
+        const screenNameMatch = location.pathname.match(new RegExp(`^${APP_URL_PREFIX}/([^/]+)`));
 
         if (!screenNameMatch) {
             return undefined;

--- a/src/components/layout/screens/StatusScreen.tsx
+++ b/src/components/layout/screens/StatusScreen.tsx
@@ -33,7 +33,7 @@ import SelfUpdatingRelativeDate from "../../shared/dataDisplay/SelfUpdatingRelat
 const StatusScreen: FC = () => {
     const dispatch = useAppDispatch();
     const { colors } = useMantineTheme();
-    const [clearMediaCache, clearMediaCacheStatus] = useLazyClearMediaCachesQuery();
+    const [clearMediaCache] = useLazyClearMediaCachesQuery();
     const { refetch: refetchAlbums } = useGetAlbumsQuery();
     const { refetch: refetchNewAlbums } = useGetNewAlbumsQuery();
     const { refetch: refetchArtists } = useGetArtistsQuery();

--- a/src/components/layout/screens/TracksScreen.tsx
+++ b/src/components/layout/screens/TracksScreen.tsx
@@ -14,9 +14,6 @@ import ScreenHeader from "../ScreenHeader";
 const TracksScreen: FC = () => {
     const dispatch = useAppDispatch();
     const { HEADER_HEIGHT, SCREEN_HEADER_HEIGHT } = useAppGlobals();
-    const currentTrackMediaId = useAppSelector(
-        (state: RootState) => state.playback.current_track_media_id
-    );
     const [currentTrackRef, setCurrentTrackRef] = useState<RefObject<HTMLDivElement>>();
     const { scrollPosition } = useAppSelector((state: RootState) => state.internal.tracks);
     const [scroll, scrollTo] = useWindowScroll({ delay: 500 });
@@ -47,7 +44,7 @@ const TracksScreen: FC = () => {
             (HEADER_HEIGHT + SCREEN_HEADER_HEIGHT + buffer);
 
         window.scrollTo({ top: currentTrackTop });
-    }, [currentTrackMediaId, currentTrackRef, HEADER_HEIGHT, SCREEN_HEADER_HEIGHT, dispatch]);
+    }, [currentTrackRef, HEADER_HEIGHT, SCREEN_HEADER_HEIGHT, dispatch]);
 
     return (
         <Stack spacing={0}>

--- a/src/components/managers/BackgroundImageManager.tsx
+++ b/src/components/managers/BackgroundImageManager.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import { FC, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import type { RootState } from "../../app/store/store";

--- a/src/components/managers/MediaGroupsManager.tsx
+++ b/src/components/managers/MediaGroupsManager.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import { FC, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 // TODO: If this approach of munging the infrequently-changing list of albums and tracks and

--- a/src/components/managers/MediaSourceManager.tsx
+++ b/src/components/managers/MediaSourceManager.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
 import type { RootState } from "../../app/store/store";

--- a/src/components/managers/PlayheadManager.tsx
+++ b/src/components/managers/PlayheadManager.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
 import type { RootState } from "../../app/store/store";

--- a/src/components/managers/WebsocketManager.tsx
+++ b/src/components/managers/WebsocketManager.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from "react";
+import { FC } from "react";
 
 import { useGetMessagesQuery } from "../../app/services/vibinWebsocket";
 
 const WebsocketManager: FC = () => {
-    const { data } = useGetMessagesQuery(); // Trigger the websocket connection
+    useGetMessagesQuery(); // Trigger the websocket connection
 
     return null;
 };

--- a/src/components/shared/NoArtPlaceholder.tsx
+++ b/src/components/shared/NoArtPlaceholder.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from "react";
 import { Box, Center, MantineColor, Text, useMantineTheme } from "@mantine/core";
 
-type NoArtPlaceholder = {
+type NoArtPlaceholderProps = {
     artSize: number;
     backgroundColor?: MantineColor;
-}
-
-const NoArtPlaceholder: FC<NoArtPlaceholder> = ({ artSize, backgroundColor }) => {
+};
+const NoArtPlaceholder: FC<NoArtPlaceholderProps> = ({ artSize, backgroundColor }) => {
     const { colors } = useMantineTheme();
 
     return (

--- a/src/components/shared/buttons/MediaActionsButton.tsx
+++ b/src/components/shared/buttons/MediaActionsButton.tsx
@@ -145,8 +145,8 @@ const MediaActionsButton: FC<MediaActionsButtonProps> = ({
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const [addMediaToPlaylist, addStatus] = useAddMediaToPlaylistMutation();
-    const [addFavorite, addFavoriteStatus] = useAddFavoriteMutation();
-    const [deleteFavorite, deleteFavoriteStatus] = useDeleteFavoriteMutation();
+    const [addFavorite] = useAddFavoriteMutation();
+    const [deleteFavorite] = useDeleteFavoriteMutation();
     const { favorites } = useAppSelector((state: RootState) => state.favorites);
     const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
     const albumById = useAppSelector((state: RootState) => state.mediaGroups.albumById);

--- a/src/components/shared/buttons/PlayMediaIdsButton.tsx
+++ b/src/components/shared/buttons/PlayMediaIdsButton.tsx
@@ -42,7 +42,7 @@ const PlayMediaIdsButton: FC<PlayMediaIdsButtonProps> = ({
     const theme = useMantineTheme();
     const menuStyles = useMenuStyles();
     const currentSource = useAppSelector((state: RootState) => state.playback.current_audio_source);
-    const [setPlaylistIds, setPlaylistIdsStatus] = useSetPlaylistMediaIdsMutation();
+    const [setPlaylistIds] = useSetPlaylistMediaIdsMutation();
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
     const isLocalMedia = currentSource ? currentSource.class === "stream.media" : false;

--- a/src/components/shared/dataDisplay/PlayStateIndicator.tsx
+++ b/src/components/shared/dataDisplay/PlayStateIndicator.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactElement } from "react";
-import { Flex, Loader, Text, Tooltip, useMantineTheme } from "@mantine/core";
+import { Flex, Loader, Text, useMantineTheme } from "@mantine/core";
 import { IconPlayerPlay, IconPlayerPause } from "@tabler/icons";
 
 import { useAppSelector } from "../../../app/hooks/useInterval";

--- a/src/components/shared/textDisplay/LoadingDataMessage.tsx
+++ b/src/components/shared/textDisplay/LoadingDataMessage.tsx
@@ -9,7 +9,7 @@ type LoadingDataMessageProps = {
 
 const LoadingDataMessage: FC<LoadingDataMessageProps> = ({ message, delay = 500 }) => {
     const [show, setShow] = useState<boolean>(false);
-    const { start, clear } = useTimeout(() => setShow(true), delay, { autoInvoke: true });
+    useTimeout(() => setShow(true), delay, { autoInvoke: true });
 
     return show ? (
         <Flex gap="sm" align="center">


### PR DESCRIPTION
Mostly unused imports and unused hook values.

Not dealing with warnings related to `useEffect()` and `useCallback()` dependencies as changing those is more likely to impact behavior. Saving those for a separate PR.