### PR TITLE
Clean up ESLint warnings related to React hook dependencies

### DIFF
--- a/src/app/hooks/useWindowScroll.ts
+++ b/src/app/hooks/useWindowScroll.ts
@@ -45,7 +45,7 @@ export function useWindowScroll(options?: Partial<{ delay: number }>) {
 
     useEffect(() => {
         setPosition(getScrollPosition());
-    }, []);
+    }, [setPosition]);
 
     return [position, scrollTo] as const;
 }

--- a/src/components/features/albums/AlbumCard.tsx
+++ b/src/components/features/albums/AlbumCard.tsx
@@ -247,7 +247,7 @@ const AlbumCard: FC<AlbumCardProps> = ({
                     })
                 );
         }
-    }, [cardRef, isVisible, cardSize, showDetails]);
+    }, [cardRef, isVisible, cardSize, showDetails, latestVisibleRenderSize, dispatch]);
 
     const visibilityOffset = type === "art_focused" ? -1000 : -200;
 

--- a/src/components/features/albums/AlbumsWall.tsx
+++ b/src/components/features/albums/AlbumsWall.tsx
@@ -43,7 +43,7 @@ const AlbumsWall: FC<AlbumWallProps> = ({ onNewCurrentAlbumRef }) => {
 
     useEffect(() => {
         onNewCurrentAlbumRef(currentAlbumRef);
-    }, []);
+    }, [onNewCurrentAlbumRef]);
 
     useEffect(() => {
         if (!allAlbums || allAlbums.length <= 0) {

--- a/src/components/features/artists/ArtistsWall.tsx
+++ b/src/components/features/artists/ArtistsWall.tsx
@@ -148,37 +148,28 @@ const ArtistsWall: FC = () => {
     // recorded position.
 
     // Store the current scroll positions.
-    const throttledArtistsPosChange = useCallback(
-        throttle(
-            (value) => {
-                dispatch(setArtistsScrollPos({ category: "artists", pos: value.y }));
-            },
-            SCROLL_POS_DISPATCH_RATE,
-            { leading: false }
-        ),
-        []
+    const throttledArtistsPosChange = throttle(
+        (value) => {
+            dispatch(setArtistsScrollPos({ category: "artists", pos: value.y }));
+        },
+        SCROLL_POS_DISPATCH_RATE,
+        { leading: false }
     );
 
-    const throttledAlbumsPosChange = useCallback(
-        throttle(
-            (value) => {
-                dispatch(setArtistsScrollPos({ category: "albums", pos: value.y }));
-            },
-            SCROLL_POS_DISPATCH_RATE,
-            { leading: false }
-        ),
-        []
+    const throttledAlbumsPosChange = throttle(
+        (value) => {
+            dispatch(setArtistsScrollPos({ category: "albums", pos: value.y }));
+        },
+        SCROLL_POS_DISPATCH_RATE,
+        { leading: false }
     );
 
-    const throttledTracksPosChange = useCallback(
-        throttle(
-            (value) => {
-                dispatch(setArtistsScrollPos({ category: "tracks", pos: value.y }));
-            },
-            SCROLL_POS_DISPATCH_RATE,
-            { leading: false }
-        ),
-        []
+    const throttledTracksPosChange = throttle(
+        (value) => {
+            dispatch(setArtistsScrollPos({ category: "tracks", pos: value.y }));
+        },
+        SCROLL_POS_DISPATCH_RATE,
+        { leading: false }
     );
 
     // When the Artist Wall mounts, do one of the follow:
@@ -227,6 +218,7 @@ const ArtistsWall: FC = () => {
                     tracksViewport.current.scrollTo({ top: tracksScrollPos });
             }, 1);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const scrollSelectedIntoView = useCallback(() => {

--- a/src/components/features/playlist/PlaylistControls.tsx
+++ b/src/components/features/playlist/PlaylistControls.tsx
@@ -246,7 +246,7 @@ const PlaylistControls: FC<PlaylistControlsProps> = ({ scrollToCurrent }) => {
                 message: `[${status}] ${JSON.stringify(data)}`,
             });
         }
-    }, [activatePlaylistStatus.isSuccess, activatePlaylistStatus.isError]);
+    }, [activatePlaylistStatus, storedPlaylists, activeStoredPlaylistId]);
 
     /**
      *
@@ -267,7 +267,14 @@ const PlaylistControls: FC<PlaylistControlsProps> = ({ scrollToCurrent }) => {
                 message: `[${status}] ${JSON.stringify(data)}`,
             });
         }
-    }, [storePlaylistStatus.isSuccess, storePlaylistStatus.isError, newPlaylistName]);
+    }, [
+        storePlaylistStatus.isSuccess,
+        storePlaylistStatus.isError,
+        newPlaylistName,
+        storePlaylistStatus,
+        activeStoredPlaylistName,
+        activatePlaylistStatus.error,
+    ]);
 
     // --------------------------------------------------------------------------------------------
 

--- a/src/components/features/playlist/StoredPlaylistsEditor.tsx
+++ b/src/components/features/playlist/StoredPlaylistsEditor.tsx
@@ -76,6 +76,7 @@ const StoredPlaylistsEditor: FC = () => {
     }, [
         updateStoredPlaylistNameStatus.isSuccess,
         updateStoredPlaylistNameStatus.isError,
+        updateStoredPlaylistNameStatus.error,
         storedPlaylists,
     ]);
 

--- a/src/components/features/tracks/TrackCard.tsx
+++ b/src/components/features/tracks/TrackCard.tsx
@@ -227,7 +227,7 @@ const TrackCard: FC<TrackCardProps> = ({
                     })
                 );
         }
-    }, [cardRef, isVisible, cardSize, showDetails]);
+    }, [cardRef, isVisible, cardSize, showDetails, latestVisibleRenderSize, dispatch]);
 
     const visibilityOffset = type === "art_focused" ? -1000 : -200;
 

--- a/src/components/features/tracks/TracksWall.tsx
+++ b/src/components/features/tracks/TracksWall.tsx
@@ -45,7 +45,7 @@ const TracksWall: FC<TrackWallProps> = ({ onNewCurrentTrackRef }) => {
 
     useEffect(() => {
         onNewCurrentTrackRef(currentTrackRef);
-    }, []);
+    }, [onNewCurrentTrackRef]);
 
 
     useEffect(() => {

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -66,19 +66,16 @@ const RootLayout: FC = () => {
         `${window.innerWidth}x${window.innerHeight}`
     );
 
-    const screenName = (): string | undefined => {
+    useEffect(() => {
         const screenNameMatch = location.pathname.match(new RegExp(`^${APP_URL_PREFIX}/([^/]+)`));
 
         if (!screenNameMatch) {
-            return undefined;
+            return;
         }
 
-        return screenNameMatch[1] || "";
-    }
-
-    useEffect(() => {
-        dispatch(setCurrentScreen(screenName() || ""));
-    }, [location, dispatch, APP_URL_PREFIX]);
+        const screenName = screenNameMatch[1] || "";
+        dispatch(setCurrentScreen(screenName || ""));
+    }, [location, APP_URL_PREFIX, dispatch]);
 
     // Create a key unique to the current screen and window dimensions. If any of those things
     // change (e.g. a window resize) then the key is changed. This key then becomes the key prop
@@ -146,7 +143,7 @@ const RootLayout: FC = () => {
                 {/* Enable the background image manager for select screens. Enabling it on all
                     screens results in unwanted full renders of those other screens when the
                     current track changes. */}
-                {["current", "playlist"].includes(screenName() || "") && <BackgroundImageManager />}
+                {["current", "playlist"].includes(currentScreen) && <BackgroundImageManager />}
 
                 {/* The Debug pane */}
                 <Box

--- a/src/components/layout/screens/AlbumsScreen.tsx
+++ b/src/components/layout/screens/AlbumsScreen.tsx
@@ -20,6 +20,7 @@ const AlbumsScreen: FC = () => {
 
     useEffect(() => {
         setTimeout(() => scrollTo({ y: scrollPosition }), 1);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/src/components/layout/screens/FavoritesScreen.tsx
+++ b/src/components/layout/screens/FavoritesScreen.tsx
@@ -18,6 +18,7 @@ const FavoritesScreen: FC = () => {
 
     useEffect(() => {
         setTimeout(() => scrollTo({ y: scrollPosition }), 1);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/src/components/layout/screens/PlaylistScreen.tsx
+++ b/src/components/layout/screens/PlaylistScreen.tsx
@@ -97,15 +97,12 @@ const PlaylistScreen: FC = () => {
     /**
      *
      */
-    const throttledPlaylistPositionChange = useCallback(
-        throttle(
-            (value) => {
-                dispatch(setPlaylistScrollPosition(value.y));
-            },
-            SCROLL_POS_DISPATCH_RATE,
-            { leading: false }
-        ),
-        []
+    const throttledPlaylistPositionChange = throttle(
+        (value) => {
+            dispatch(setPlaylistScrollPosition(value.y));
+        },
+        SCROLL_POS_DISPATCH_RATE,
+        { leading: false }
     );
 
     // --------------------------------------------------------------------------------------------

--- a/src/components/layout/screens/PresetsScreen.tsx
+++ b/src/components/layout/screens/PresetsScreen.tsx
@@ -18,6 +18,7 @@ const PresetsScreen: FC = () => {
 
     useEffect(() => {
         setTimeout(() => scrollTo({ y: scrollPosition }), 1);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/src/components/layout/screens/TracksScreen.tsx
+++ b/src/components/layout/screens/TracksScreen.tsx
@@ -20,6 +20,7 @@ const TracksScreen: FC = () => {
 
     useEffect(() => {
         setTimeout(() => scrollTo({ y: scrollPosition }), 1);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/src/components/managers/MediaSourceManager.tsx
+++ b/src/components/managers/MediaSourceManager.tsx
@@ -38,6 +38,12 @@ const MediaSourceManager: FC = () => {
         else {
             currentSource?.name && setHaveIgnoredInitialState(true);
         }
+
+        // TODO: Figure out how to not require eslint-disable-next-line. It's there because this
+        //  component does not want to notify the user of the media source whenever the app is
+        //  first loaded, which doesn't work when haveIgnoredInitialState is in the dependency list.
+        //
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dispatch, currentSource]);
 
     return null;


### PR DESCRIPTION
This involves a mix of proper cleanup (adding missing dependencies); telling ESLint to ignore the issue (when the effect is intended to be a mount-time-only operation); and removing `useCallback()` when it's not required.