### PR TITLE
Migrate from deprecated WebSocket message types; minor fixes

### DIFF
--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -55,19 +55,15 @@ const MAX_MESSAGE_COUNT = 10;
 type SimpleObject = { [key: string | number]: any };
 
 type MessageType =
-    | "ActiveTransportControls"
     | "CurrentlyPlaying"
-    | "DeviceDisplay"
     | "Favorites"
-    | "PlayState"
     | "Position"
     | "Presets"
     | "StoredPlaylists"
     | "System"
+    | "TransportState"
     | "UPnPProperties"
     | "VibinStatus";
-
-type ActiveTransportControlsPayload = TransportAction[];
 
 // ------------------------------------------------------------------------------------------------
 // TODO: Figure out where these new types should live
@@ -94,6 +90,12 @@ type MediaStream = {
     url: string;
 };
 
+// TODO: End new types
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// Message payload shapes.
+
 type CurrentlyPlayingPayload = {
     album_media_id: MediaId;
     track_media_id: MediaId;
@@ -106,10 +108,15 @@ type CurrentlyPlayingPayload = {
     stream: MediaStream;
 };
 
-// TODO: End new types
-// ------------------------------------------------------------------------------------------------
+type FavoritesPayload = FavoritesState;
 
-type DeviceDisplayPayload = DeviceDisplay;
+type PositionPayload = {
+    position: number;
+};
+
+type PresetsPayload = PresetsState;
+
+type StoredPlaylistsPayload = StoredPlaylistsState;
 
 type SystemPayload = {
     streamer: {
@@ -118,11 +125,19 @@ type SystemPayload = {
         sources: {
             active: AudioSource,
             available: AudioSource[],
-        }
+        };
+        display: DeviceDisplay;
     };
     media: {
         name: string;
     };
+};
+
+type TransportStatePayload = {
+    play_state: PlayStatus,
+    active_controls: TransportAction[],
+    repeat: RepeatState,
+    shuffle: ShuffleState,
 };
 
 type UPnPPropertiesPayload = {
@@ -133,72 +148,29 @@ type UPnPPropertiesPayload = {
     vibin: SimpleObject;
 };
 
-// TODO: Figure out if any of these are not optional. Making them all optional makes usage a little
-//  awkward (having to always allow for their optionality on reference). Also investigate
-//  formalizing some of these types, and find a suitable place fro those types to live.
-type PlayStatePayload = {
-    state?: PlayStatus;
-    position?: number;
-    presettable?: boolean;
-    queue_index?: number;
-    queue_length?: number;
-    queue_id?: number;
-    mode_repeat?: RepeatState;
-    mode_shuffle?: ShuffleState;
-    metadata?: {
-        class?: string;
-        source?: string;
-        name?: string;
-        playback_source?: string;
-        track_number?: number;
-        duration?: number;
-        album?: string;
-        artist?: string;
-        title?: string;
-        art_url?: string;
-        sample_format?: string;
-        mqa?: string;
-        codec?: string;
-        lossless?: boolean;
-        sample_rate?: number;
-        bit_depth?: number;
-        encoding?: string;
-        current_track_media_id: string | undefined;
-        current_album_media_id: string | undefined;
-    };
-};
-
-type PositionPayload = {
-    position: number;
-};
-
-type PresetsPayload = PresetsState;
-
-type FavoritesPayload = FavoritesState;
-
-type StoredPlaylistsPayload = StoredPlaylistsState;
-
 type VibinStatusPayload = VibinStatusState;
 
-// TODO: More clearly define the vibin backend message format.
+// ------------------------------------------------------------------------------------------------
+// The overall message shape.
+
 export type VibinMessage = {
     id: string;
     client_id: string;
     time: number;
     type: MessageType;
     payload:
-        | ActiveTransportControlsPayload
         | CurrentlyPlayingPayload
-        | DeviceDisplayPayload
         | FavoritesPayload
-        | PlayStatePayload
         | PositionPayload
         | PresetsPayload
         | StoredPlaylistsPayload
         | SystemPayload
+        | TransportStatePayload
         | UPnPPropertiesPayload
         | VibinStatusPayload;
 };
+
+// ------------------------------------------------------------------------------------------------
 
 /**
  * Take some arbitrary input (scalar or SimpleObject) and purify it. Purify in this context means
@@ -239,36 +211,13 @@ const purifyData = (
  * @param dispatch
  *
  *  1. Add the message to the message stream.
- *  2. Extract the following information (if present in the message) and, if the data has changed
- *     from the current application state, then dispatch redux actions to update the state:
- *      * Playback status
- *          * Playback state (paused, playing, etc.)
- *          * List of audio sources.
- *          * Current audio source.
- *          * Current track information (artist, title, etc).
- *          * Current format information (code, bitrate, etc).
- *      * Current playlist
+ *  2. Check the message type ("CurrentlyPlaying", "Favorites", etc) and use the information in the
+ *     message payload to dispatch updates to application state.
  *
  * TODO: updateCachedData is coming from the QueryArg type, defined somewhere in Redux Toolkit. It
  *  would be nice to figure out how to access the proper type and not fall back on "any".
  *  messageHandler() might also benefit at some point from having the entire QueryArg object rather
  *  than just updateCachedData.
- *
- * TODO: The backend currently supports two message types (state var updates, and play state
- *  updates). Should these even be treated differently? (Their backend realities are different --
- *  UPNP vs. WebSocket updates from the streamer -- but that distinction could be abstracted away).
- *  If continued to treat differently, then maybe the Client/UI could decide whether they want to
- *  receive one or both types -- perhaps by connecting to a WebSocket channel per type; or sending
- *  a connect message where they say which type(s) they want to receive.
- *
- * TODO: Handle defining the current playhead position. Store it as normalized 0-1 in application
- *  state. Auto-update at regular interval (say 250ms). Heuristics:
- *      * When current track has changed, set playhead to 0.
- *      * Auto-update playhead position at regular interval.
- *      * Actions to consider (will interrupt regular-interval updates):
- *          * Track paused (pause updates; allow for pause happening mid-interval).
- *          * Track stopped (cancel playhead?).
- *          * Track seek (reset position).
  */
 function messageHandler(
     updateCachedData: any,
@@ -293,7 +242,28 @@ function messageHandler(
 
         const appState = getState();
 
-        if (data.type === "System") {
+        if (data.type === "CurrentlyPlaying") {
+            const currentlyPlaying = data.payload as CurrentlyPlayingPayload;
+
+            dispatch(setCurrentTrack(currentlyPlaying.active_track));
+            dispatch(setCurrentTrackMediaId(currentlyPlaying.track_media_id));
+            dispatch(setCurrentAlbumMediaId(currentlyPlaying.album_media_id));
+            dispatch(setCurrentFormat(currentlyPlaying.format));
+            dispatch(setCurrentStream(currentlyPlaying.stream));
+            dispatch(setCurrentTrackIndex(currentlyPlaying.playlist.current_track_index));
+            dispatch(setEntries(currentlyPlaying.playlist.entries));
+        } else if (data.type === "Favorites") {
+            dispatch(setFavoritesState(data.payload as FavoritesPayload));
+        } else if (data.type === "Position") {
+            dispatch({
+                type: setPlayheadPosition.type,
+                payload: (data.payload as PositionPayload).position,
+            });
+        } else if (data.type === "Presets") {
+            dispatch(setPresetsState(data.payload as PresetsState));
+        } else if (data.type === "StoredPlaylists") {
+            dispatch(setStoredPlaylistsState(data.payload as StoredPlaylistsPayload));
+        } else if (data.type === "System") {
             const system = data.payload as SystemPayload;
 
             dispatch(setMediaDeviceName(system.media?.name));
@@ -301,34 +271,22 @@ function messageHandler(
             dispatch(setStreamerPower(system.streamer?.power));
             dispatch(setAudioSources(system.streamer?.sources.available))
             dispatch(setCurrentAudioSource(system.streamer?.sources.active))
-        } else if (data.type === "CurrentlyPlaying") {
-            const currentlyPlaying = data.payload as CurrentlyPlayingPayload;
+            dispatch(setDeviceDisplay(system.streamer?.display));
+        } else if (data.type === "TransportState") {
+            const payload = data.payload as TransportStatePayload;
 
-            dispatch(setCurrentTrackMediaId(currentlyPlaying.track_media_id));
-            dispatch(setCurrentAlbumMediaId(currentlyPlaying.album_media_id));
+            dispatch(setPlayStatus(payload.play_state));  // "play", "pause", etc
+            dispatch(setActiveTransportActions(payload.active_controls));
+            dispatch(setRepeat(payload.repeat));
+            dispatch(setShuffle(payload.shuffle));
         } else if (data.type === "UPnPProperties") {
+            // TODO: This is still used for active track genre. Need to refactor this.
             const upnpProperties = data.payload as UPnPPropertiesPayload;
             const streamerName = upnpProperties.streamer_name;
 
             if (!streamerName) {
                 return;
             }
-
-            // Set list of audio sources, and currently-set audio source.
-            // dispatch(setAudioSources(upnpProperties.vibin.streamer?.audio_sources || {}));
-            // dispatch(setCurrentAudioSource(upnpProperties.vibin.streamer?.current_audio_source));
-
-            // Set stream information.
-            const streamInfo = upnpProperties.vibin.streamer?.current_playback_details?.stream;
-
-            streamInfo &&
-                dispatch(
-                    setCurrentStream({
-                        type: streamInfo.type,
-                        source_name: streamInfo.source_name,
-                        url: streamInfo.url,
-                    })
-                );
 
             // Extract track genre, checking to ensure that the message's track matches the track
             // in application state.
@@ -354,76 +312,6 @@ function messageHandler(
                     })
                 );
             }
-
-            // Set current playlist track index and entries.
-            dispatch(
-                setCurrentTrackIndex(upnpProperties.vibin.streamer?.current_playlist_track_index)
-            );
-            dispatch(setEntries(upnpProperties.vibin.streamer?.current_playlist));
-        } else if (data.type === "Position") {
-            dispatch({
-                type: setPlayheadPosition.type,
-                payload: (data.payload as PositionPayload).position,
-            });
-        } else if (data.type === "PlayState") {
-            const metadata = (data.payload as PlayStatePayload).metadata;
-
-            // Set current play status ("play", "pause", etc).
-            dispatch(setPlayStatus((data.payload as PlayStatePayload).state));
-
-            // Set current Track and Album Media IDs.
-            // dispatch(
-            //     setCurrentTrackMediaId(
-            //         (data.payload as PlayStatePayload).metadata?.current_track_media_id
-            //     )
-            // );
-            // dispatch(
-            //     setCurrentAlbumMediaId(
-            //         (data.payload as PlayStatePayload).metadata?.current_album_media_id
-            //     )
-            // );
-
-            // Set track information.
-            // NOTE: genre comes later from a UPnPProperties message.
-            metadata &&
-                dispatch(
-                    setCurrentTrack({
-                        track_number: metadata.track_number,
-                        duration: metadata.duration,
-                        album: metadata.album,
-                        artist: metadata.artist,
-                        title: metadata.title,
-                        art_url: metadata.art_url,
-                    })
-                );
-
-            // Set format information.
-            metadata &&
-                dispatch(
-                    setCurrentFormat({
-                        sample_format: metadata.sample_format,
-                        mqa: metadata.mqa,
-                        codec: metadata.codec,
-                        lossless: metadata.lossless,
-                        sample_rate: metadata.sample_rate,
-                        bit_depth: metadata.bit_depth,
-                        encoding: metadata.encoding,
-                    })
-                );
-
-            // Set repeat and shuffle.
-            dispatch(setRepeat((data.payload as PlayStatePayload).mode_repeat));
-            dispatch(setShuffle((data.payload as PlayStatePayload).mode_shuffle));
-        } else if (data.type === "ActiveTransportControls") {
-            dispatch(setActiveTransportActions(data.payload as ActiveTransportControlsPayload));
-        } else if (data.type === "DeviceDisplay") {
-            dispatch(setDeviceDisplay(data.payload as DeviceDisplayPayload));
-        } else if (data.type === "Favorites") {
-            dispatch(setFavoritesState(data.payload as FavoritesPayload));
-        } else if (data.type === "Presets") {
-            dispatch(setPresetsState(data.payload as PresetsState));
-        } else if (data.type === "StoredPlaylists") {
-            dispatch(setStoredPlaylistsState(data.payload as StoredPlaylistsPayload));
         } else if (data.type === "VibinStatus") {
             dispatch(setVibinStatusState(data.payload as VibinStatusPayload));
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -63,8 +63,6 @@ export type Format = {
 
 // A file being streamed for playback.
 export type Stream = {
-    type: string;
-    source_name: string;
     url: string;
 }
 

--- a/src/components/features/CurrentTrackScreen.tsx
+++ b/src/components/features/CurrentTrackScreen.tsx
@@ -162,7 +162,7 @@ const CurrentTrackScreen: FC = () => {
             // down the line is expecting any keys that aren't being provided here.
             setCurrentTrack({
                 artist: currentPlaybackTrack.artist,
-                album: currentPlaybackTrack.artist,
+                album: currentPlaybackTrack.album,
                 title: currentPlaybackTrack.title,
                 art_url: currentPlaybackTrack.art_url,
                 album_art_uri: currentPlaybackTrack.art_url,


### PR DESCRIPTION
* Remove reliance on WebSocket message types: `ActiveTransportControls`, `DeviceDisplay`, and `PlayState`. This information is now retrieved from other messages (mostly `CurrentlyPlaying` and `TransportState`).
* Fix bug showing artist name as the album name for non-local tracks (e.g. AirPlay).