### PR TITLE
Tweak BG image support, genre extraction, and add media source to AppNav

### DIFF
--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -280,38 +280,15 @@ function messageHandler(
             dispatch(setRepeat(payload.repeat));
             dispatch(setShuffle(payload.shuffle));
         } else if (data.type === "UPnPProperties") {
-            // TODO: This is still used for active track genre. Need to refactor this.
-            const upnpProperties = data.payload as UPnPPropertiesPayload;
-            const streamerName = upnpProperties.streamer_name;
-
-            if (!streamerName) {
-                return;
-            }
-
-            // Extract track genre, checking to ensure that the message's track matches the track
-            // in application state.
+            // TODO: This is where the current track's genre used to be extracted from. Investigate
+            //  where best to find genre now. The ultimate dispatch for genre looked like:
             //
-            // NOTE: This assumes we'll be getting a UPnPProperties message for the track *after*
-            // we've seen a PlayState message defining the new track.
-            const upnpPropertiesTrack =
-                upnpProperties.vibin.streamer?.current_playback_details?.playlist_entry;
-            const appStateTrack = appState[setCurrentTrack.type];
-
-            if (
-                upnpPropertiesTrack &&
-                appStateTrack &&
-                upnpPropertiesTrack.genre &&
-                appStateTrack.title === upnpPropertiesTrack.title &&
-                appStateTrack.album === upnpPropertiesTrack.album &&
-                appStateTrack.artist === upnpPropertiesTrack.artist
-            ) {
-                dispatch(
-                    setCurrentTrack({
-                        ...appState[setCurrentTrack.type],
-                        genre: upnpPropertiesTrack.genre,
-                    })
-                );
-            }
+            // dispatch(
+            //     setCurrentTrack({
+            //         ...appState[setCurrentTrack.type],
+            //         genre: upnpPropertiesTrack.genre,
+            //     })
+            // );
         } else if (data.type === "VibinStatus") {
             dispatch(setVibinStatusState(data.payload as VibinStatusPayload));
 

--- a/src/components/app/layout/AppNav.tsx
+++ b/src/components/app/layout/AppNav.tsx
@@ -27,6 +27,7 @@ import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
 import SettingsMenu from "../SettingsMenu";
 import WaitingOnAPIIndicator from "../../shared/dataDisplay/WaitingOnAPIIndicator";
 import StandbyMode from "../../shared/buttons/StandbyMode";
+import MediaSourceBadge from "../../shared/dataDisplay/MediaSourceBadge";
 
 // ================================================================================================
 // Application navigation menu.
@@ -201,6 +202,10 @@ const AppNav: FC<AppNavProps> = ({ noBackground = false }) => {
                     </Stack>
                 </Stack>
             </Navbar.Section>
+
+            <Box>
+                <MediaSourceBadge showSource={true} />
+            </Box>
 
             <Navbar.Section className={classes.footer}>
                 <Flex justify="space-between" align="center">

--- a/src/components/app/managers/BackgroundImageManager.tsx
+++ b/src/components/app/managers/BackgroundImageManager.tsx
@@ -19,7 +19,8 @@ const BackgroundImageManager: FC = () => {
     const currentTrackId = useAppSelector(
         (state: RootState) => state.playback.current_track_media_id
     );
-    const currentPlaybackTrack = useAppSelector((state: RootState) => state.playback.current_track);
+    const { current_track: currentPlaybackTrack, current_audio_source: currentAudioSource } =
+        useAppSelector((state: RootState) => state.playback);
 
     /**
      * Set the background image URL. This will change whenever the current track changes. If
@@ -32,6 +33,7 @@ const BackgroundImageManager: FC = () => {
         if (currentTrackId && trackById[currentTrackId]) {
             dispatch(setCurrentlyPlayingArtUrl(trackById[currentTrackId].album_art_uri));
         } else if (
+            currentAudioSource?.class === "stream.media" &&
             activePlaylist &&
             activePlaylist.entries &&
             activePlaylist.current_track_index !== undefined &&


### PR DESCRIPTION
* Remove genre extraction from `UPnPProperties` WebSocket message (will need to find alternate means for determining genre)
* Add `<MediaSourceBadge>` to `<AppNav>`
* Tweak `<BackgroundImageManager>` to only pull BG image from playlist entry when current audio source is `stream.media` (this ensures that AirPlay/etc art will be used when not playing local media)