### PR TITLE
Fix regression breaking favorite playback; fix scroll on modal display

### DIFF
--- a/src/components/app/layout/RootLayout.tsx
+++ b/src/components/app/layout/RootLayout.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useEffect, useState } from "react";
-import { Outlet, ScrollRestoration, useLocation } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import {
     AppShell,
     Box,
@@ -145,14 +145,6 @@ const RootLayout: FC = () => {
                     {/* The route <Outlet> is the main screen (Albums, Artists, etc) */}
                     <Outlet />
                 </Stack>
-
-                {/* NOTE: Scroll restoration doesn't work screens which use components based on
-                <VisibilitySensor> (which is most screens, including Artists, Albums, Tracks). */}
-                <ScrollRestoration
-                    getKey={(location, matches) => {
-                        return location.pathname;
-                    }}
-                />
 
                 <KeyboardShortcutsManager />
 

--- a/src/components/shared/buttons/PlayMediaIdsButton.tsx
+++ b/src/components/shared/buttons/PlayMediaIdsButton.tsx
@@ -1,6 +1,15 @@
 import React, { FC, useState } from "react";
-import { ActionIcon, Box, createStyles, Menu, Tooltip, useMantineTheme } from "@mantine/core";
-import { IconPlayerPlay } from "@tabler/icons";
+import {
+    ActionIcon,
+    Box,
+    createStyles,
+    Flex,
+    Menu,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from "@mantine/core";
+import { IconCircleOff, IconPlayerPlay } from "@tabler/icons";
 
 import { MediaId } from "../../../app/types";
 import { useAppSelector } from "../../../app/hooks/store";
@@ -45,14 +54,25 @@ const PlayMediaIdsButton: FC<PlayMediaIdsButtonProps> = ({
 }) => {
     const theme = useMantineTheme();
     const menuStyles = useMenuStyles();
-    const currentSource = useAppSelector((state: RootState) => state.playback.current_audio_source);
+    const { power: streamerPower } = useAppSelector((state: RootState) => state.system.streamer);
     const [setPlaylistIds] = useSetPlaylistMediaIdsMutation();
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
-    const isLocalMedia = currentSource ? currentSource.class === "stream.media" : false;
+    const isInStandbyMode = streamerPower === "off";
+
+    // TODO: Investigate ways to clearly and consistently let the user know when capabilities are
+    //  unavailable due to the streamer being in standby.
+    const label = isInStandbyMode ? (
+        <Flex gap={5} align="center">
+            <IconCircleOff size={14} />
+            <Text>Streamer is in standby</Text>
+        </Flex>
+    ) : (
+        tooltipLabel
+    );
 
     return (
-        <Tooltip label={tooltipLabel} disabled={menuOpen} position="bottom">
+        <Tooltip label={label} disabled={menuOpen} position="bottom">
             <Box sx={{ alignSelf: "center" }}>
                 <Menu
                     withArrow
@@ -67,13 +87,13 @@ const PlayMediaIdsButton: FC<PlayMediaIdsButtonProps> = ({
                         <ActionIcon
                             variant="light"
                             color={theme.primaryColor}
-                            disabled={disabled || !isLocalMedia || mediaIds.length === 0}
+                            disabled={disabled || mediaIds.length === 0 || isInStandbyMode}
                         >
                             <IconPlayerPlay size="1rem" />
                         </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown>
-                        <Menu.Label>Playlist</Menu.Label>
+                        <Menu.Label>Modify Playlist</Menu.Label>
                         <Menu.Item
                             icon={
                                 <IconPlayerPlay


### PR DESCRIPTION
Fix regression where the playlist could no longer be replaced with favorites. Also add tooltip showing that this capability is disabled when the streamer is in standby.

Remove `<ScrollRestoration>` from `<RootLayout>` as it was forcing scroll-to-top behavior when a modal (such as lyrics or hotkeys) was shown, and it didn't seem to be doing anything useful otherwise.

Notes:

* Need to think about a standardized app-wide approach to showing the user when capabilities are disabled due to the streamer being in standby.
* Need to find a good way to restore scroll position when returning to large screens like Albums and Tracks.