### PR TITLE
Handle missing waveforms and RMS

### DIFF
--- a/src/app/store/internalSlice.ts
+++ b/src/app/store/internalSlice.ts
@@ -18,6 +18,7 @@ export interface InternalState {
         showCurrentTrackLyrics: boolean;
         showKeyboardShortcuts: boolean;
         showDebugPanel: boolean;
+        waveformsSupported: boolean;
         websocketClientId: string | undefined;
         websocketStatus: WebsocketStatus;
     };
@@ -86,6 +87,7 @@ const initialState: InternalState = {
         showCurrentTrackLyrics: false,
         showKeyboardShortcuts: false,
         showDebugPanel: false,
+        waveformsSupported: true,
         websocketClientId: undefined,
         websocketStatus: "disconnected",
     },
@@ -277,6 +279,9 @@ export const internalSlice = createSlice({
         setTracksScrollPosition: (state, action: PayloadAction<number>) => {
             state.tracks.scrollPosition = action.payload;
         },
+        setWaveformsSupported: (state, action: PayloadAction<boolean>) => {
+            state.application.waveformsSupported = action.payload;
+        },
         setWebsocketClientId: (state, action: PayloadAction<string>) => {
             state.application.websocketClientId = action.payload;
         },
@@ -317,6 +322,7 @@ export const {
     setShowKeyboardShortcuts,
     setTrackCardRenderDimensions,
     setTracksScrollPosition,
+    setWaveformsSupported,
     setWebsocketClientId,
     setWebsocketStatus,
 } = internalSlice.actions;

--- a/src/components/shared/mediaDisplay/TrackLinks.tsx
+++ b/src/components/shared/mediaDisplay/TrackLinks.tsx
@@ -87,7 +87,7 @@ const TrackLinks: FC<TrackLinksProps> = ({ trackId, artist, album, title }) => {
     }
 
     if (!data || Object.keys(data).length <= 0) {
-        return <SadLabel label="No links found" />;
+        return <SadLabel label="No links found" labelSize={14} weight="normal" />;
     }
 
     return (

--- a/src/components/shared/mediaDisplay/TrackLyrics.tsx
+++ b/src/components/shared/mediaDisplay/TrackLyrics.tsx
@@ -93,7 +93,7 @@ const TrackLyrics: FC<TrackLyricsProps> = ({ trackId, artist, title }) => {
     if (!lyrics || lyrics.chunks.length <= 0) {
         return (
             <Stack spacing={20}>
-                <SadLabel label="No lyrics found" />
+                <SadLabel label="No lyrics found" labelSize={14} weight="normal" />
                 <Button
                     compact
                     variant="light"

--- a/src/components/shared/textDisplay/SadLabel.tsx
+++ b/src/components/shared/textDisplay/SadLabel.tsx
@@ -9,13 +9,14 @@ type SadLabelProps = {
     label: string;
     labelSize?: number;
     sadSize?: number;
+    weight?: string;
 };
 
-const SadLabel: FC<SadLabelProps> = ({ label, labelSize = 16, sadSize = 26 }) => {
+const SadLabel: FC<SadLabelProps> = ({ label, labelSize = 16, sadSize = 26, weight = "bold" }) => {
     return (
         <Flex gap="0.8rem" align="center" miw="15rem">
             <Text size={sadSize}>😔</Text>
-            <Text size={labelSize} weight="bold" miw="fit-content">{label}</Text>
+            <Text size={labelSize} weight={weight} miw="fit-content">{label}</Text>
         </Flex>
     );
 };


### PR DESCRIPTION
If a single error ever comes back from the RMS request, then have the app assume that waveforms and RMS are not supported by the backend.

This is a bit hacky. A better solution might involve having the backend announce what features it supports in its `VibinStatus` message.