### PR TITLE
Display a "buffering audio" overlay when buffering takes >3 secs

### DIFF
--- a/src/app/hooks/useAppGlobals.ts
+++ b/src/app/hooks/useAppGlobals.ts
@@ -58,6 +58,7 @@ export const useAppGlobals = () => {
         SCREEN_HEADER_HEIGHT: 70,
         SCROLL_POS_DISPATCH_RATE: 500,
         SELECTED_COLOR: "rgba(25, 113, 194, 0.2)",
+        BUFFERING_AUDIO_NOTIFY_DELAY: 3000,
         STYLE_LABEL_BESIDE_COMPONENT: {
             root: {
                 display: "flex",

--- a/src/components/shared/textDisplay/BufferingLoader.tsx
+++ b/src/components/shared/textDisplay/BufferingLoader.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from "react";
+import { Flex, Loader, Text } from "@mantine/core";
+
+// ================================================================================================
+// A loader intended to be used by Mantine's <LoadingOverlay>, to notify the user that audio is
+// being buffered by the streamer.
+//
+// It's up to the caller to determine if/when <BufferingLoader> should be displayed (via
+// <LoadingOverlay>. TODO: Could this component control its own (and <LoadingOverlay>'s) display.
+// ================================================================================================
+
+const BufferingLoader: FC = () => {
+    return (
+        <Flex direction="row" gap={10}>
+            <Loader size="sm" variant="bars" />
+            <Text weight={400}>buffering audio...</Text>
+        </Flex>
+    );
+}
+
+export default BufferingLoader;


### PR DESCRIPTION
* Added new `<BufferingLoader>` component.
* Used new loader in `<PlaybackControls>` so loader is visible from all app routes. This is overridden by a full-screen loader if the user is in the "Current Track" screen (`<CurrentTrackScreen>`).
* Loader will not display until the streamer has been buffering for >3 seconds. This is because buffering takes place briefly between all tracks, and the goal here is to notify the user only when buffering has taken long enough to feel weird (e.g. when the NAS is spinning up from sleep; or when switching audio sources).