### PR TITLE
Improve setting of currentTrack to provide as much Track info as possible

### DIFF
--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -30,7 +30,7 @@ import { setPresetsState, PresetsState } from "../store/presetsSlice";
 import { setFavoritesState, FavoritesState } from "../store/favoritesSlice";
 import { setStoredPlaylistsState, StoredPlaylistsState } from "../store/storedPlaylistsSlice";
 import { setVibinStatusState, VibinStatusState } from "../store/vibinStatusSlice";
-import { MediaId, PlaylistEntry } from "../types";
+import { MediaId, PlaylistEntry, Track } from "../types";
 
 // ================================================================================================
 // Handle the WebSocket connection to the vibin backend.
@@ -243,10 +243,19 @@ function messageHandler(
         if (data.type === "CurrentlyPlaying") {
             const currentlyPlaying = data.payload as CurrentlyPlayingPayload;
 
-            dispatch(setCurrentTrack({
-                id: currentlyPlaying.track_media_id,  // id will be undefined for non-local media
-                ...currentlyPlaying.active_track
-            }));
+            // Set the currentTrack details. If a local track is currently playing (i.e. there's
+            // a track_media_id) then set the currentTrack to the Track associated with the Id.
+            // If there's no track_media_id (e.g. currently playing from AirPlay) then set the
+            // currentTrack to a "fake" Track based on active_track (active_track only has some
+            // Track fields defined, as sources like AirPlay do not define all Track fields).
+            const localMediaTrackDetails: Track | undefined =
+                currentlyPlaying.track_media_id &&
+                getState().mediaGroups.trackById[currentlyPlaying.track_media_id];
+            
+            dispatch(
+                setCurrentTrack(localMediaTrackDetails || (currentlyPlaying.active_track as Track))
+            );
+
             dispatch(setCurrentTrackMediaId(currentlyPlaying.track_media_id));
             dispatch(setCurrentAlbumMediaId(currentlyPlaying.album_media_id));
             dispatch(setCurrentFormat(currentlyPlaying.format));

--- a/src/app/store/playbackSlice.ts
+++ b/src/app/store/playbackSlice.ts
@@ -80,6 +80,13 @@ export interface PlaybackState {
     // TODO: Audio Sources doesn't belong in current playback slice
     audio_sources: AudioSource[];
     current_audio_source: AudioSource | undefined;
+    // TODO: The current_track will either be a complete Track (when the track is being sourced from
+    //  local media where the complete Track details are known); or a partial Track (when the track
+    //  is being sourced from a non-local source like AirPlay, where only some Track details are
+    //  known. This is a little messy and can result in different keys for things like the art url.
+    //  This should be cleaned up to properly support a more flexible-yet-consistent Track
+    //  definition. That said, the current_track can be assumed to provide as much Track information
+    //  as possible for what is currently playing, regardless of source.
     current_track: Track | undefined;
     // TODO: For the "current ids", consider adding Artist -- and also storing full
     //  Artist/Album/Track objects rather than just ids (so the other information, like title, is


### PR DESCRIPTION
If a local track is currently playing (i.e. there's a `track_media_id`) then set the `currentTrack` to the Track associated with the Id. If there's no `track_media_id` (e.g. currently playing from AirPlay) then set the `currentTrack` to a "fake" Track based on `active_track` (`active_track` -- provided by the streamer -- only has some Track fields defined, as sources like AirPlay do not define all Track fields).