### PR TITLE
Improve current track display for other sources, and keyboard shortcuts

### DIFF
--- a/src/components/features/playlist/Playlist.tsx
+++ b/src/components/features/playlist/Playlist.tsx
@@ -278,7 +278,10 @@ const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef, onPlaylistModified 
 
     // --------------------------------------------------------------------------------------------
 
-    if (playStatus === "not_ready") {
+    // Disallow playlist display while the streamer is off. This may not be strictly necessary, but
+    // it provides a more intuitive (to me) user experience (my mental model: if streamer is off,
+    // it can't be interacted with).
+    if (streamerPower !== "on") {
         return (
             <Box pt={35}>
                 <SystemPower showPowerOff={false} label="streamer is in standby mode" />

--- a/src/components/shared/textDisplay/SadLabel.tsx
+++ b/src/components/shared/textDisplay/SadLabel.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { Flex, Text } from "@mantine/core";
 
 // ================================================================================================
-// A label paired with a sad face emoji.
+// A label paired with an optional sad-face emoji.
 // ================================================================================================
 
 type SadLabelProps = {
@@ -10,13 +10,22 @@ type SadLabelProps = {
     labelSize?: number;
     sadSize?: number;
     weight?: string;
+    showEmoji?: boolean;
 };
 
-const SadLabel: FC<SadLabelProps> = ({ label, labelSize = 16, sadSize = 26, weight = "bold" }) => {
+const SadLabel: FC<SadLabelProps> = ({
+    label,
+    labelSize = 16,
+    sadSize = 26,
+    weight = "bold",
+    showEmoji = false,
+}) => {
     return (
         <Flex gap="0.8rem" align="center" miw="15rem">
-            <Text size={sadSize}>😔</Text>
-            <Text size={labelSize} weight={weight} miw="fit-content">{label}</Text>
+            {showEmoji && <Text size={sadSize}>😔</Text>}
+            <Text size={labelSize} weight={weight} miw="fit-content">
+                {label}
+            </Text>
         </Flex>
     );
 };


### PR DESCRIPTION
* Current track screen now shows details (when available) for other audio sources (like radio).
* Add keyboard shortcuts for 5-unit volume up/down.
* Don't show emoji by default in `<SadLabel>`.