### PR TITLE
Fix unwanted vertical scrollbar on <CurrentTrack> screen

### DIFF
--- a/src/components/app/layout/RootLayout.tsx
+++ b/src/components/app/layout/RootLayout.tsx
@@ -154,6 +154,7 @@ const RootLayout: FC = () => {
                 header={<AppHeader noBackground={RENDER_APP_BACKGROUND_IMAGE} />}
                 styles={(theme) => ({
                     main: {
+                        paddingBottom: 0,
                         backgroundColor: RENDER_APP_BACKGROUND_IMAGE
                             ? "rgb(0, 0, 0, 0)"
                             : theme.colorScheme === "dark"


### PR DESCRIPTION
The scrollbar appeared due to a fix to Mantine in 6.0.1:

https://github.com/mantinedev/mantine/issues/3678

It turns out Vibin was relying on the bottom padding not being set properly. This fix hardcodes the `paddingBottom` to `0` to restore the old behavior.

This only affected the `<CurrentTrack>` screen.

Ideally the top-level application layout would be rethought to be less convoluted and more clear in how it manages window height, scrollbars, etc.