### PR TITLE
Simplify logic for play/pause and system power

### DIFF
--- a/src/app/services/vibinSystem.ts
+++ b/src/app/services/vibinSystem.ts
@@ -50,6 +50,9 @@ export const vibinSystemApi = createApi({
         streamerSourceSet: builder.mutation<void, string>({
             query: (sourceName) => ({ url: `streamer/audio_source/${sourceName}`, method: "POST" }),
         }),
+        systemPowerSet: builder.mutation<void, PowerState>({
+            query: (power) => ({ url: `power/${power}`, method: "POST" }),
+        }),
     }),
 });
 
@@ -65,4 +68,5 @@ export const {
     useStreamerPowerSetMutation,
     useStreamerPowerToggleMutation,
     useStreamerSourceSetMutation,
+    useSystemPowerSetMutation,
 } = vibinSystemApi;

--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -7,6 +7,7 @@ import {
     setAmplifierState,
     setMediaServerState,
     setStreamerState,
+    setSystemPower,
 } from "../store/systemSlice";
 import {
     PlayStatus,
@@ -120,6 +121,7 @@ type PresetsPayload = PresetsState;
 type StoredPlaylistsPayload = StoredPlaylistsState;
 
 type SystemPayload = {
+    power: "on" | "off";
     streamer: {
         name: string;
         power: "on" | "off" | undefined;
@@ -286,6 +288,7 @@ function messageHandler(
         } else if (data.type === "System") {
             const system = data.payload as SystemPayload;
 
+            dispatch(setSystemPower(system.power));
             dispatch(setAmplifierState(system.amplifier));
             dispatch(setMediaServerState(system.media));
             dispatch(setStreamerState(system.streamer));

--- a/src/app/store/systemSlice.ts
+++ b/src/app/store/systemSlice.ts
@@ -71,12 +71,14 @@ export interface AmplifierState extends DeviceState {
 }
 
 export interface SystemState {
+    power: PowerState;
     streamer: StreamerState;
     media_server: MediaServerState;
     amplifier: AmplifierState;
 }
 
 const initialState: SystemState = {
+    power: "off",
     streamer: {
         name: "",
         power: undefined,
@@ -108,6 +110,9 @@ export const systemSlice = createSlice({
         setStreamerState: (state, action: PayloadAction<StreamerState>) => {
             updateIfDifferent(state, "streamer", action.payload);
         },
+        setSystemPower: (state, action: PayloadAction<PowerState>) => {
+            updateIfDifferent(state, "power", action.payload);
+        },
     },
 });
 
@@ -116,6 +121,7 @@ export const {
     setAmplifierState,
     setMediaServerState,
     setStreamerState,
+    setSystemPower,
 } = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/src/components/app/managers/KeyboardShortcutsManager.tsx
+++ b/src/components/app/managers/KeyboardShortcutsManager.tsx
@@ -8,6 +8,7 @@ import { RootState } from "../../../app/store/store";
 import {
     useAmplifierMuteToggleMutation,
     useAmplifierVolumeSetMutation,
+    useSystemPowerSetMutation,
 } from "../../../app/services/vibinSystem";
 import {
     useNextTrackMutation,
@@ -15,7 +16,6 @@ import {
     usePlayMutation,
     usePreviousTrackMutation,
     useSeekMutation,
-    useTogglePlaybackMutation,
 } from "../../../app/services/vibinTransport";
 import FieldValueList from "../../shared/dataDisplay/FieldValueList";
 import {
@@ -48,12 +48,13 @@ const KeyboardShortcutsManager: FC = () => {
     const position = useAppSelector((state: RootState) => state.playback.playhead.position);
     const amplifier = useAppSelector((state: RootState) => state.system.amplifier);
     const amplifierVolume = useAppSelector((state: RootState) => state.system.amplifier?.volume);
+    const systemPower = useAppSelector((state: RootState) => state.system.power);
     const [debouncedAmplifierVolume] = useDebouncedValue(amplifierVolume, 2000);
+    const [systemPowerSet] = useSystemPowerSetMutation();
     const [volumeSet] = useAmplifierVolumeSetMutation();
     const [amplifierMuteToggle] = useAmplifierMuteToggleMutation();
     const [pausePlayback] = usePauseMutation();
     const [playPlayback] = usePlayMutation();
-    const [togglePlayback] = useTogglePlaybackMutation();
     const [nextTrack] = useNextTrackMutation();
     const [previousTrack] = usePreviousTrackMutation();
     const [seek] = useSeekMutation();
@@ -113,18 +114,7 @@ const KeyboardShortcutsManager: FC = () => {
                     activeTransportActions.includes("seek") &&
                     seek(Math.max(position - SEEK_OFFSET_SECS, 0)),
             ],
-            [
-                "K",
-                () => {
-                    const preferToggle = activeTransportActions.includes("toggle_playback");
-
-                    preferToggle
-                        ? togglePlayback()
-                        : playStatus === "play"
-                        ? pausePlayback()
-                        : playPlayback();
-                },
-            ],
+            ["K", () => (playStatus === "play" ? pausePlayback() : playPlayback())],
             [
                 "L",
                 () =>
@@ -141,6 +131,7 @@ const KeyboardShortcutsManager: FC = () => {
             ["T", () => navigate("/ui/tracks")],
             ["E", () => navigate("/ui/presets")],
             ["F", () => navigate("/ui/favorites")],
+            ["ctrl+shift+1", () => systemPowerSet(systemPower === "on" ? "off" : "on")],
             ["shift+?", () => dispatch(setShowKeyboardShortcuts(!showKeyboardShortcuts))],
             ["shift+L", () => dispatch(setShowCurrentTrackLyrics(true))],
         ],
@@ -157,8 +148,9 @@ const KeyboardShortcutsManager: FC = () => {
             previousTrack,
             seek,
             SEEK_OFFSET_SECS,
+            systemPower,
+            systemPowerSet,
             showKeyboardShortcuts,
-            togglePlayback,
         ]
     );
 
@@ -330,30 +322,55 @@ const KeyboardShortcutsManager: FC = () => {
                         </Stack>
                     </Paper>
 
-                    {/* Additional ------------------------------------------------------------ */}
-                    <Paper p="md" radius={5} withBorder sx={{ flexGrow: 1 }}>
-                        <Stack spacing="sm">
-                            <Stack spacing={0}>
-                                <Text weight="bold" transform="uppercase">
-                                    Additional
-                                </Text>
+                    {/* System ----------------------------------------------------------------- */}
+                    <Stack spacing="md">
+                        <Paper p="md" radius={5} withBorder sx={{ flexGrow: 1 }}>
+                            <Stack spacing="sm">
+                                <Stack spacing={0}>
+                                    <Text weight="bold" transform="uppercase">
+                                        System
+                                    </Text>
+                                </Stack>
+                                <FieldValueList
+                                    fieldValues={{
+                                        "^⇧1": "Power system on/off",
+                                    }}
+                                    columnGap={10}
+                                    keySize={16}
+                                    keyWeight="bold"
+                                    keyColor={colors.gray[1]}
+                                    valueSize={16}
+                                    valueWeight="normal"
+                                    valueColor={colors.gray[5]}
+                                />
                             </Stack>
-                            <FieldValueList
-                                fieldValues={{
-                                    "?": "Show this Help screen",
-                                    "⇧L": "Show the current track lyrics",
-                                    "⇧D": "Show the Debug panel",
-                                }}
-                                columnGap={10}
-                                keySize={16}
-                                keyWeight="bold"
-                                keyColor={colors.gray[1]}
-                                valueSize={16}
-                                valueWeight="normal"
-                                valueColor={colors.gray[5]}
-                            />
-                        </Stack>
-                    </Paper>
+                        </Paper>
+
+                        {/* Additional ------------------------------------------------------------ */}
+                        <Paper p="md" radius={5} withBorder sx={{ flexGrow: 1 }}>
+                            <Stack spacing="sm">
+                                <Stack spacing={0}>
+                                    <Text weight="bold" transform="uppercase">
+                                        Additional
+                                    </Text>
+                                </Stack>
+                                <FieldValueList
+                                    fieldValues={{
+                                        "?": "Show this Help screen",
+                                        "⇧L": "Show the current track lyrics",
+                                        "⇧D": "Show the Debug panel",
+                                    }}
+                                    columnGap={10}
+                                    keySize={16}
+                                    keyWeight="bold"
+                                    keyColor={colors.gray[1]}
+                                    valueSize={16}
+                                    valueWeight="normal"
+                                    valueColor={colors.gray[5]}
+                                />
+                            </Stack>
+                        </Paper>
+                    </Stack>
                 </Flex>
             </Stack>
         </Modal>

--- a/src/components/features/CurrentTrackScreen.tsx
+++ b/src/components/features/CurrentTrackScreen.tsx
@@ -274,7 +274,7 @@ const CurrentTrackScreen: FC = () => {
     if (streamerPower !== "on") {
         return (
             <Box pt={35}>
-                <SystemPower showPowerOff={false} label="streamer is in standby mode" />
+                <SystemPower label="streamer is in standby mode" />
             </Box>
         );
     }

--- a/src/components/features/playlist/Playlist.tsx
+++ b/src/components/features/playlist/Playlist.tsx
@@ -284,7 +284,7 @@ const Playlist: FC<PlaylistProps> = ({ onNewCurrentEntryRef, onPlaylistModified 
     if (streamerPower !== "on") {
         return (
             <Box pt={35}>
-                <SystemPower showPowerOff={false} label="streamer is in standby mode" />
+                <SystemPower label="streamer is in standby mode" />
             </Box>
         );
     }

--- a/src/components/shared/buttons/SystemPower.tsx
+++ b/src/components/shared/buttons/SystemPower.tsx
@@ -1,81 +1,42 @@
 import React, { FC } from "react";
 import { ActionIcon, Box, Flex, Text, Tooltip } from "@mantine/core";
-import { IconArrowDownCircle, IconPower } from "@tabler/icons";
+import { IconPower } from "@tabler/icons";
 
 import { useAppSelector } from "../../../app/hooks/store";
 import { RootState } from "../../../app/store/store";
-import {
-    useAmplifierPowerSetMutation,
-    useStreamerPowerSetMutation,
-} from "../../../app/services/vibinSystem";
+import { useSystemPowerSetMutation } from "../../../app/services/vibinSystem";
 
 // ================================================================================================
 // Power the system on/off.
 // ================================================================================================
 
 type SystemPowerProps = {
-    showPowerOn?: boolean;
-    showPowerOff?: boolean;
     label?: string;
 };
 
-const SystemPower: FC<SystemPowerProps> = ({
-    showPowerOn = true,
-    showPowerOff = true,
-    label = "",
-}) => {
-    const [amplifierPowerSet] = useAmplifierPowerSetMutation();
-    const [streamerPowerSet] = useStreamerPowerSetMutation();
-    const streamerPower = useAppSelector((state: RootState) => state.system.streamer.power);
-    const amplifierPower = useAppSelector((state: RootState) => state.system.amplifier?.power);
+const SystemPower: FC<SystemPowerProps> = ({ label = "" }) => {
+    const [systemPowerSet] = useSystemPowerSetMutation();
+    const systemPower = useAppSelector((state: RootState) => state.system.power);
 
     return (
         <Flex gap={10} justify="center" align="center">
-            {showPowerOff && (
-                <Tooltip label="Power system off" position="top" withArrow>
-                    <Box>
-                        <ActionIcon
-                            size="lg"
-                            color="blue"
-                            variant={
-                                streamerPower === "on" || amplifierPower === "on"
-                                    ? "light"
-                                    : "transparent"
-                            }
-                            radius={5}
-                            onClick={() => {
-                                streamerPowerSet("off");
-                                amplifierPower && amplifierPowerSet("off");
-                            }}
-                        >
-                            <IconArrowDownCircle size={20} />
-                        </ActionIcon>
-                    </Box>
-                </Tooltip>
-            )}
-
-            {showPowerOn && (
-                <Tooltip label="Power system on" position="top" withArrow>
-                    <Box>
-                        <ActionIcon
-                            size="lg"
-                            color="blue"
-                            variant={
-                                streamerPower === "off" || amplifierPower === "off"
-                                    ? "light"
-                                    : "transparent"
-                            }
-                            radius={5}
-                            onClick={() => {
-                                streamerPowerSet("on");
-                                amplifierPower && amplifierPowerSet("on");
-                            }}
-                        >
-                            <IconPower size={20} />
-                        </ActionIcon>
-                    </Box>
-                </Tooltip>
-            )}
+            <Tooltip
+                label={`Power system ${systemPower === "on" ? "off" : "on"}`}
+                position="top"
+                withArrow
+            >
+                <Box>
+                    <ActionIcon
+                        size="lg"
+                        color={systemPower === "on" ? "red" : "blue"}
+                        variant={systemPower === "on" ? "light" : "filled"}
+                        radius={5}
+                        onClick={() => systemPowerSet(systemPower === "on" ? "off" : "on")}
+                    >
+                        <IconPower size={20} />
+                    </ActionIcon>
+                </Box>
+            </Tooltip>
 
             {label !== "" && <Text>{label}</Text>}
         </Flex>

--- a/src/components/shared/playbackControls/TransportControls.tsx
+++ b/src/components/shared/playbackControls/TransportControls.tsx
@@ -16,7 +16,6 @@ import {
     usePlayMutation,
     usePreviousTrackMutation,
     useStopMutation,
-    useTogglePlaybackMutation,
     useToggleRepeatMutation,
     useToggleShuffleMutation,
 } from "../../../app/services/vibinTransport";
@@ -29,7 +28,7 @@ import { RootState } from "../../../app/store/store";
 //
 // Contents:
 //  - Previous Track.
-//  - Play/Pause/Toggle/Stop.
+//  - Play/Pause/Stop.
 //  - Next Track.
 //  - Repeat.
 //  - Shuffle.
@@ -55,7 +54,6 @@ const TransportControls: FC = () => {
     const [playPlayback] = usePlayMutation();
     const [previousTrack] = usePreviousTrackMutation();
     const [stopPlayback] = useStopMutation();
-    const [togglePlayback] = useTogglePlaybackMutation();
     const [toggleRepeat] = useToggleRepeatMutation();
     const [toggleShuffle] = useToggleShuffleMutation();
     const [playPresetId] = useLazyPlayPresetIdQuery();
@@ -97,9 +95,8 @@ const TransportControls: FC = () => {
                     }
                     sx={disabledStyles}
                     onClick={() =>
-                        activeTransportActions.includes("toggle_playback")
-                            ? togglePlayback()
-                            : activeTransportActions.includes("pause")
+                        activeTransportActions.includes("toggle_playback") ||
+                        activeTransportActions.includes("pause")
                             ? pausePlayback()
                             : stopPlayback()
                     }
@@ -133,9 +130,7 @@ const TransportControls: FC = () => {
                             const active_preset = presets.find((preset) => preset.is_playing);
                             active_preset && playPresetId(active_preset.id);
                         } else {
-                            activeTransportActions.includes("toggle_playback")
-                                ? togglePlayback()
-                                : playPlayback();
+                            playPlayback();
                         }
                     }}
                 >


### PR DESCRIPTION
* Backend now supports the same play/pause API for all source types, no longer requiring the UI to explicitly do a playback toggle for some sources and play/pause for other sources.
* Power button duo is now a single button which changes color to reflect whether the system is currently on or off.
* Added a keyboard shortcut for system power on/off.