### PR TITLE
Fix display of `<ArtModal>` and `<MediaSummaryBanner>`

### DIFF
--- a/src/components/features/CurrentTrackScreen.tsx
+++ b/src/components/features/CurrentTrackScreen.tsx
@@ -364,7 +364,7 @@ const CurrentTrackScreen: FC = () => {
                         <MediaArt
                             media={currentTrack}
                             size={albumArtWidth}
-                            showPlayButton={false}
+                            showControls={false}
                         />
                         {(playStatusDisplay === "pause" || playStatusDisplay === "stop") && (
                             <PlaybackPaused />

--- a/src/components/shared/mediaDisplay/ArtModal.tsx
+++ b/src/components/shared/mediaDisplay/ArtModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Modal, Stack } from "@mantine/core";
+import { Flex, Modal, Stack } from "@mantine/core";
 
 import { isAlbum, isPreset, isTrack, Media } from "../../../app/types";
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
@@ -20,7 +20,7 @@ const ArtModal: FC<ArtModalProps> = ({ media, opened, onClose = undefined }) => 
     const { APP_MODAL_BLUR } = useAppGlobals();
 
     const title = isAlbum(media)
-        ? "Track Art"
+        ? "Album Art"
         : isTrack(media)
         ? "Track Art"
         : isPreset(media)
@@ -39,7 +39,9 @@ const ArtModal: FC<ArtModalProps> = ({ media, opened, onClose = undefined }) => 
         >
             <Stack>
                 <MediaSummaryBanner media={media} showArt={false} />
-                <MediaArt media={media} />
+                <Flex>
+                    <MediaArt media={media} showControls={false} />
+                </Flex>
             </Stack>
         </Modal>
     );

--- a/src/components/shared/textDisplay/MediaSummaryBanner.tsx
+++ b/src/components/shared/textDisplay/MediaSummaryBanner.tsx
@@ -37,14 +37,12 @@ const MediaSummaryBanner: FC<MediaSummaryBannerProps> = ({
                 <MediaArt
                     media={media}
                     size={100}
-                    showActions={showArtControls}
-                    showPlayButton={showArtControls}
+                    showControls={showArtControls}
                     actionsMenuPosition={"bottom"}
                 />
             )}
 
-            {isAlbum(media) ||
-                (isTrack(media) && (
+            {(isAlbum(media) || isTrack(media)) && (
                     <Stack sx={{ gap: 0, flexGrow: 1 }}>
                         <Text size="lg" weight="bold" sx={{ lineHeight: 1.25 }}>
                             {media.title}
@@ -59,7 +57,7 @@ const MediaSummaryBanner: FC<MediaSummaryBannerProps> = ({
                                 : ""}
                         </Text>
                     </Stack>
-                ))}
+                )}
 
             {isPreset(media) && (
                 <Stack sx={{ gap: 0, flexGrow: 1 }}>


### PR DESCRIPTION
Images weren't left-aligned, and media details (e.g. title) weren't displaying.