### PR TITLE
Switch from `@tabler/icons` v1 to `@tabler/icons-react` v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vibinui",
-    "version": "1.1.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vibinui",
-            "version": "1.1.0",
+            "version": "1.3.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "@emotion/react": "^11.10.5",
@@ -16,7 +16,7 @@
                 "@mantine/hooks": "^6.0.0",
                 "@mantine/notifications": "^6.0.0",
                 "@reduxjs/toolkit": "^1.9.1",
-                "@tabler/icons": "^1.119.0",
+                "@tabler/icons-react": "^2.35.0",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
@@ -3814,24 +3814,28 @@
             }
         },
         "node_modules/@tabler/icons": {
-            "version": "1.119.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.119.0.tgz",
-            "integrity": "sha512-Fk3Qq4w2SXcTjc/n1cuL5bccPkylrOMo7cYpQIf/yw6zP76LQV9dtLcHQUjFiUnaYuswR645CnURIhlafyAh9g==",
+            "version": "2.35.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.35.0.tgz",
+            "integrity": "sha512-qW/itKdmFvfGw6mAQ+cZy+2MYTXb0XdGAVhO3obYLJEfsSPMwQRO0S9ckFk1xMQX/Tj7REC3TEmWUBWNi3/o3g==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/codecalm"
+            }
+        },
+        "node_modules/@tabler/icons-react": {
+            "version": "2.35.0",
+            "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.35.0.tgz",
+            "integrity": "sha512-jK2zgtMF2+LSjtbjYsfer+ryz72TwyJqv3MsmCfEpQwP37u01xvmTlVhJ+ox3bV+trsgjojsldVDuB05JuXLaw==",
+            "dependencies": {
+                "@tabler/icons": "2.35.0",
+                "prop-types": "^15.7.2"
+            },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/codecalm"
             },
             "peerDependencies": {
-                "react": "^16.x || 17.x || 18.x",
-                "react-dom": "^16.x || 17.x || 18.x"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "@mantine/hooks": "^6.0.0",
         "@mantine/notifications": "^6.0.0",
         "@reduxjs/toolkit": "^1.9.1",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^2.35.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,6 +1,6 @@
-import { ReactNode } from "react";
+import { createElement, ReactNode } from "react";
 import { showNotification } from "@mantine/notifications";
-import { IconAlertCircle, IconCheck, IconX } from "@tabler/icons";
+import { IconAlertCircle, IconCheck, IconX } from "@tabler/icons-react";
 import get from "lodash/get";
 import dayjs from "dayjs";
 import localizedFormat from "dayjs/plugin/localizedFormat";
@@ -114,7 +114,7 @@ export const showSuccessNotification = ({
         title,
         message,
         color: color || "teal",
-        icon: icon || IconCheck({ size: 18 }),
+        icon: icon || createElement(IconCheck, { size: 18 }),
         loading,
         autoClose,
     });
@@ -136,7 +136,7 @@ export const showWarningNotification = ({
         title,
         message,
         color: color || "yellow",
-        icon: icon || IconAlertCircle({ size: 21, style: { paddingRight: 1, paddingBottom: 2 } }),
+        icon: icon || createElement(IconAlertCircle, { size: 21, style: { paddingRight: 1, paddingBottom: 2 } }),
         loading,
         autoClose,
     });
@@ -158,7 +158,7 @@ export const showErrorNotification = ({
         title,
         message,
         color: color || "red",
-        icon: icon || IconX({ size: 18 }),
+        icon: icon || createElement(IconX, { size: 18 }),
         loading,
         autoClose,
     });

--- a/src/components/app/SettingsMenu.tsx
+++ b/src/components/app/SettingsMenu.tsx
@@ -9,7 +9,7 @@ import {
     Switch,
     useMantineColorScheme,
 } from "@mantine/core";
-import { IconBug, IconKeyboard, IconMoon, IconSettings, IconSun } from "@tabler/icons";
+import { IconBug, IconKeyboard, IconMoon, IconSettings, IconSun } from "@tabler/icons-react";
 
 import { RootState } from "../../app/store/store";
 import { useAppDispatch, useAppSelector } from "../../app/hooks/store";

--- a/src/components/app/layout/AppNav.tsx
+++ b/src/components/app/layout/AppNav.tsx
@@ -13,6 +13,7 @@ import {
     useMantineTheme, ActionIcon
 } from "@mantine/core";
 import {
+    Icon,
     IconDeviceSpeaker,
     IconDisc,
     IconHeart,
@@ -22,8 +23,7 @@ import {
     IconRadio,
     IconSearch,
     IconUser,
-    TablerIcon,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
 import { useAppDispatch } from "../../../app/hooks/store";
@@ -127,7 +127,7 @@ const AppNav: FC<AppNavProps> = ({ noBackground = false }) => {
     const { classes, cx } = useStyles();
     const { APP_URL_PREFIX, APP_PADDING, NAVBAR_WIDTH } = useAppGlobals();
 
-    const routeInfo: Record<string, { link: string; label: string; icon: TablerIcon }[]> = {
+    const routeInfo: Record<string, { link: string; label: string; icon: Icon }[]> = {
         "Now Playing": [
             { link: `${APP_URL_PREFIX}/current`, label: "Current Track", icon: IconDeviceSpeaker },
             { link: `${APP_URL_PREFIX}/playlist`, label: "Playlist", icon: IconPlaylist },

--- a/src/components/features/CurrentTrackScreen.tsx
+++ b/src/components/features/CurrentTrackScreen.tsx
@@ -16,7 +16,7 @@ import {
     useMantineTheme,
 } from "@mantine/core";
 import { useDebouncedValue, useTimeout, useWindowEvent } from "@mantine/hooks";
-import { IconPlayerPlay } from "@tabler/icons";
+import { IconPlayerPlay } from "@tabler/icons-react";
 
 import { RootState } from "../../app/store/store";
 import { useAppDispatch, useAppSelector } from "../../app/hooks/store";

--- a/src/components/features/StatusScreen.tsx
+++ b/src/components/features/StatusScreen.tsx
@@ -14,7 +14,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from "@mantine/core";
-import { IconMoodSmile, IconRefresh } from "@tabler/icons";
+import { IconMoodSmile, IconRefresh } from "@tabler/icons-react";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks/store";
 import { RootState } from "../../app/store/store";

--- a/src/components/features/albums/AlbumsControls.tsx
+++ b/src/components/features/albums/AlbumsControls.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
 import { ActionIcon, Flex, Select, TextInput } from "@mantine/core";
-import { IconSquareX } from "@tabler/icons";
+import { IconSquareX } from "@tabler/icons-react";
 
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";
 import {

--- a/src/components/features/albums/AppendAlbumTrackToPlaylistButton.tsx
+++ b/src/components/features/albums/AppendAlbumTrackToPlaylistButton.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect } from "react";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { Box, createStyles, Tooltip } from "@mantine/core";
 import { updateNotification } from "@mantine/notifications";
-import { IconCheck, IconExclamationMark, IconPlaylistAdd } from "@tabler/icons";
+import { IconCheck, IconExclamationMark, IconPlaylistAdd } from "@tabler/icons-react";
 
 import { Album, Track } from "../../../app/types";
 import { useAddMediaToPlaylistMutation } from "../../../app/services/vibinActivePlaylist";

--- a/src/components/features/artists/ArtistsControls.tsx
+++ b/src/components/features/artists/ArtistsControls.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback } from "react";
 import { ActionIcon, Box, Flex, Select, TextInput, Tooltip, useMantineTheme } from "@mantine/core";
+import { IconHandFinger, IconSquareX } from "@tabler/icons-react";
 
 import { Album, Artist, MediaId, Track } from "../../../app/types";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";
@@ -17,7 +18,6 @@ import { RootState } from "../../../app/store/store";
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
 import { useGetArtistsQuery } from "../../../app/services/vibinArtists";
 import { useGetTracksQuery } from "../../../app/services/vibinTracks";
-import { IconHandFinger, IconSquareX } from "@tabler/icons";
 import ShowCountLabel from "../../shared/textDisplay/ShowCountLabel";
 import CurrentlyPlayingButton from "../../shared/buttons/CurrentlyPlayingButton";
 

--- a/src/components/features/favorites/FavoritesControls.tsx
+++ b/src/components/features/favorites/FavoritesControls.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { ActionIcon, Flex, Select, TextInput } from "@mantine/core";
-import { IconSquareX } from "@tabler/icons";
+import { IconSquareX } from "@tabler/icons-react";
 
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";

--- a/src/components/features/playlist/Playlist.tsx
+++ b/src/components/features/playlist/Playlist.tsx
@@ -10,7 +10,7 @@ import {
     Text,
     useMantineTheme,
 } from "@mantine/core";
-import { IconGripVertical, IconPlayerPause, IconPlayerPlay, IconTrash } from "@tabler/icons";
+import { IconGripVertical, IconPlayerPause, IconPlayerPlay, IconTrash } from "@tabler/icons-react";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 
 import { PlaylistEntry } from "../../../app/types";

--- a/src/components/features/playlist/PlaylistControls.tsx
+++ b/src/components/features/playlist/PlaylistControls.tsx
@@ -28,7 +28,7 @@ import {
     IconFilePlus,
     IconListDetails,
     IconMenu2,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { RootState } from "../../../app/store/store";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";

--- a/src/components/features/playlist/PlaylistEntryActionsButton.tsx
+++ b/src/components/features/playlist/PlaylistEntryActionsButton.tsx
@@ -17,7 +17,7 @@ import {
     IconPlayerPlay,
     IconTrash,
     IconWaveSine,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { PlaylistEntry } from "../../../app/types";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";

--- a/src/components/features/playlist/StoredPlaylistsManager.tsx
+++ b/src/components/features/playlist/StoredPlaylistsManager.tsx
@@ -16,7 +16,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from "@mantine/core";
-import { IconTrash } from "@tabler/icons";
+import { IconTrash } from "@tabler/icons-react";
 
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";
 import {

--- a/src/components/features/presets/PresetsControls.tsx
+++ b/src/components/features/presets/PresetsControls.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { ActionIcon, Flex, TextInput } from "@mantine/core";
-import { IconSquareX } from "@tabler/icons";
+import { IconSquareX } from "@tabler/icons-react";
 
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";
 import { setPresetsFilterText } from "../../../app/store/userSettingsSlice";

--- a/src/components/features/tracks/TracksControls.tsx
+++ b/src/components/features/tracks/TracksControls.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from "react";
 import { ActionIcon, Box, Flex, TextInput } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
-import { IconSquareX } from "@tabler/icons";
+import { IconSquareX } from "@tabler/icons-react";
 
 import { RootState } from "../../../app/store/store";
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";

--- a/src/components/shared/VibinLogo.tsx
+++ b/src/components/shared/VibinLogo.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { Center, Flex, Text, ThemeIcon, createStyles } from "@mantine/core";
-import { IconPlant2 } from "@tabler/icons";
+import { IconPlant2 } from "@tabler/icons-react";
 
 import CustomFonts from "../app/customFonts/CustomFonts";
 import { useAppGlobals } from "../../app/hooks/useAppGlobals";

--- a/src/components/shared/buttons/CurrentlyPlayingButton.tsx
+++ b/src/components/shared/buttons/CurrentlyPlayingButton.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { ActionIcon, Box, Tooltip, useMantineTheme } from "@mantine/core";
-import { IconCurrentLocation } from "@tabler/icons";
+import { IconCurrentLocation } from "@tabler/icons-react";
 
 // ================================================================================================
 // Button to scroll to the currently-playing media.

--- a/src/components/shared/buttons/FavoriteIndicator.tsx
+++ b/src/components/shared/buttons/FavoriteIndicator.tsx
@@ -1,7 +1,7 @@
 import React, { FC, SVGAttributes, useEffect } from "react";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { ActionIcon, Box, Tooltip, useMantineTheme } from "@mantine/core";
-import { IconHeart } from "@tabler/icons";
+import { IconHeart } from "@tabler/icons-react";
 
 import { isAlbum, Media, MediaId } from "../../../app/types";
 import {

--- a/src/components/shared/buttons/FollowCurrentlyPlayingToggle.tsx
+++ b/src/components/shared/buttons/FollowCurrentlyPlayingToggle.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { ActionIcon, Box, Tooltip, useMantineTheme } from "@mantine/core";
-import { IconArrowAutofitHeight } from "@tabler/icons";
+import { IconArrowAutofitHeight } from "@tabler/icons-react";
 
 import { useAppSelector } from "../../../app/hooks/store";
 import { RootState } from "../../../app/store/store";

--- a/src/components/shared/buttons/MediaActionsButton.tsx
+++ b/src/components/shared/buttons/MediaActionsButton.tsx
@@ -19,7 +19,7 @@ import {
     IconPlaylistAdd,
     IconUser,
     IconWaveSine,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { Album, isAlbum, isPreset, isTrack, Media, Track } from "../../../app/types";
 import { useAddMediaToPlaylistMutation } from "../../../app/services/vibinActivePlaylist";

--- a/src/components/shared/buttons/MediaWallDisplayControls.tsx
+++ b/src/components/shared/buttons/MediaWallDisplayControls.tsx
@@ -14,7 +14,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from "@mantine/core";
-import { IconSettings } from "@tabler/icons";
+import { IconSettings } from "@tabler/icons-react";
 
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";
 import { RootState } from "../../../app/store/store";

--- a/src/components/shared/buttons/MediaWallViewModeSelector.tsx
+++ b/src/components/shared/buttons/MediaWallViewModeSelector.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { ActionCreator } from "@reduxjs/toolkit";
 import { Center, SegmentedControl, Text } from "@mantine/core";
-import { IconGridDots, IconMenu2 } from "@tabler/icons";
+import { IconGridDots, IconMenu2 } from "@tabler/icons-react";
 
 import { useAppDispatch } from "../../../app/hooks/store";
 import { MediaWallViewMode } from "../../../app/store/userSettingsSlice";

--- a/src/components/shared/buttons/PlayButton.tsx
+++ b/src/components/shared/buttons/PlayButton.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
 import { ActionIcon, createStyles, getStylesRef, useMantineTheme } from "@mantine/core";
-import { IconPlayerPause, IconPlayerPlay } from "@tabler/icons";
+import { IconPlayerPause, IconPlayerPlay } from "@tabler/icons-react";
 
 import { isAlbum, isPreset, isTrack, Media } from "../../../app/types";
 import { useAddMediaToPlaylistMutation } from "../../../app/services/vibinActivePlaylist";

--- a/src/components/shared/buttons/PlayMediaIdsButton.tsx
+++ b/src/components/shared/buttons/PlayMediaIdsButton.tsx
@@ -9,7 +9,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from "@mantine/core";
-import { IconCircleOff, IconPlayerPlay } from "@tabler/icons";
+import { IconCircleOff, IconPlayerPlay } from "@tabler/icons-react";
 
 import { MediaId } from "../../../app/types";
 import { useAppSelector } from "../../../app/hooks/store";

--- a/src/components/shared/buttons/SystemPower.tsx
+++ b/src/components/shared/buttons/SystemPower.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { ActionIcon, Box, Flex, Text, Tooltip } from "@mantine/core";
-import { IconPower } from "@tabler/icons";
+import { IconPower } from "@tabler/icons-react";
 
 import { useAppSelector } from "../../../app/hooks/store";
 import { RootState } from "../../../app/store/store";

--- a/src/components/shared/buttons/VibinIconButton.tsx
+++ b/src/components/shared/buttons/VibinIconButton.tsx
@@ -1,6 +1,6 @@
-import React, { FC, ReactNode, SyntheticEvent } from "react";
+import React, { createElement, FC, ReactNode, SyntheticEvent } from "react";
 import { Center, createStyles, getStylesRef, Tooltip } from "@mantine/core";
-import { TablerIcon } from "@tabler/icons";
+import { Icon } from "@tabler/icons-react";
 
 // ================================================================================================
 //
@@ -9,7 +9,7 @@ import { TablerIcon } from "@tabler/icons";
 // TODO: Deprecate this and replace it with Mantine's ActionButton.
 
 type VibinIconButtonProps = {
-    icon: TablerIcon;
+    icon: Icon;
     size?: number;
     disabled?: boolean;
     container?: boolean;
@@ -67,9 +67,7 @@ const VibinIconButton: FC<VibinIconButtonProps> = ({
         onClick && !disabled && onClick();
     };
 
-    // TODO: Is there a way to keep TS happy here.
-    // @ts-ignore
-    const iconComponent: ReactNode = new icon({
+    const iconComponent: ReactNode = createElement(icon, {
         className: dynamicClasses.button,
         size,
         stroke,

--- a/src/components/shared/buttons/VolumeControl.tsx
+++ b/src/components/shared/buttons/VolumeControl.tsx
@@ -12,7 +12,7 @@ import {
     useMantineTheme,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { IconVolume, IconVolumeOff } from "@tabler/icons";
+import { IconVolume, IconVolumeOff } from "@tabler/icons-react";
 
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
 import { useAppSelector } from "../../../app/hooks/store";

--- a/src/components/shared/dataDisplay/PlayStateIndicator.tsx
+++ b/src/components/shared/dataDisplay/PlayStateIndicator.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactElement } from "react";
 import { Flex, Loader, Text, useMantineTheme } from "@mantine/core";
-import { IconPlayerPlay, IconPlayerPause } from "@tabler/icons";
+import { IconPlayerPlay, IconPlayerPause } from "@tabler/icons-react";
 
 import { useAppSelector } from "../../../app/hooks/store";
 import { RootState } from "../../../app/store/store";

--- a/src/components/shared/mediaDisplay/MediaSearchModal.tsx
+++ b/src/components/shared/mediaDisplay/MediaSearchModal.tsx
@@ -10,7 +10,7 @@ import {
     TextInput,
     useMantineTheme,
 } from "@mantine/core";
-import { IconSquareX } from "@tabler/icons";
+import { IconSquareX } from "@tabler/icons-react";
 
 import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks/store";

--- a/src/components/shared/mediaDisplay/TrackLinks.tsx
+++ b/src/components/shared/mediaDisplay/TrackLinks.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { Anchor, Button, Flex, Image, Stack, Text } from "@mantine/core";
-import { IconExternalLink } from "@tabler/icons";
+import { IconExternalLink } from "@tabler/icons-react";
 
 import { useGetLinksQuery } from "../../../app/services/vibinTracks";
 import LoadingDataMessage from "../textDisplay/LoadingDataMessage";

--- a/src/components/shared/playbackControls/TransportControls.tsx
+++ b/src/components/shared/playbackControls/TransportControls.tsx
@@ -8,7 +8,7 @@ import {
     IconPlayerTrackPrev,
     IconRepeat,
     IconArrowsShuffle,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import {
     useNextTrackMutation,

--- a/src/components/shared/textDisplay/FilterInstructions.tsx
+++ b/src/components/shared/textDisplay/FilterInstructions.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { Popover, Stack, Text, ThemeIcon, useMantineTheme } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { IconQuestionMark } from "@tabler/icons";
+import { IconQuestionMark } from "@tabler/icons-react";
 
 // ================================================================================================
 // A popover describing the supported syntax of the screen filter input text.

--- a/src/components/shared/textDisplay/WarningBanner.tsx
+++ b/src/components/shared/textDisplay/WarningBanner.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Flex, useMantineTheme } from "@mantine/core";
-import { IconAlertCircle } from "@tabler/icons";
+import { IconAlertCircle } from "@tabler/icons-react";
 
 // ================================================================================================
 // Warning banner with an alert icon.

--- a/src/components/shared/textDisplay/WarningMessage.tsx
+++ b/src/components/shared/textDisplay/WarningMessage.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { Flex, Text, useMantineTheme } from "@mantine/core";
-import { IconAlertCircle } from "@tabler/icons";
+import { IconAlertCircle } from "@tabler/icons-react";
 
 // ================================================================================================
 // Warning message with an alert icon.


### PR DESCRIPTION
This is mostly just switching the icon `import` statements, although there's also some tweaks done to some dynamic icon code in `utils.ts` and `<VibinIconButton>`.