### PR TITLE
Clean up navigation bar

### DIFF
--- a/src/app/hooks/useAppGlobals.ts
+++ b/src/app/hooks/useAppGlobals.ts
@@ -53,7 +53,7 @@ export const useAppGlobals = () => {
         HEADER_HEIGHT: 60,
         LARGE_SCREEN: largeScreen,
         MAX_TABLE_ITEMS_TO_DISPLAY: 500,
-        NAVBAR_WIDTH: largeScreen === false ? 190 : 210,
+        NAVBAR_WIDTH: largeScreen === false ? 160 : 180,
         RENDER_APP_BACKGROUND_IMAGE: renderAppBackgroundImage,
         SCREEN_LOADING_PT: 25,
         SCREEN_HEADER_HEIGHT: 70,

--- a/src/components/app/layout/AppNav.tsx
+++ b/src/components/app/layout/AppNav.tsx
@@ -31,7 +31,6 @@ import { setShowMediaSearch } from "../../../app/store/internalSlice";
 import SettingsMenu from "../SettingsMenu";
 import WaitingOnAPIIndicator from "../../shared/dataDisplay/WaitingOnAPIIndicator";
 import SystemPower from "../../shared/buttons/SystemPower";
-import MediaSourceBadge from "../../shared/dataDisplay/MediaSourceBadge";
 
 // ================================================================================================
 // Application navigation menu.
@@ -129,7 +128,7 @@ const AppNav: FC<AppNavProps> = ({ noBackground = false }) => {
 
     const routeInfo: Record<string, { link: string; label: string; icon: Icon }[]> = {
         "Now Playing": [
-            { link: `${APP_URL_PREFIX}/current`, label: "Current Track", icon: IconDeviceSpeaker },
+            { link: `${APP_URL_PREFIX}/current`, label: "Current", icon: IconDeviceSpeaker },
             { link: `${APP_URL_PREFIX}/playlist`, label: "Playlist", icon: IconPlaylist },
         ],
         Browse: [
@@ -208,12 +207,12 @@ const AppNav: FC<AppNavProps> = ({ noBackground = false }) => {
             </Navbar.Section>
 
             <Box>
-                <MediaSourceBadge showSource={true} />
+                <WaitingOnAPIIndicator stealth />
             </Box>
 
             <Navbar.Section className={classes.footer}>
                 <Flex justify="space-between" align="center">
-                    <Flex gap={10} align="center">
+                    <Flex gap={7} align="center">
                         <SettingsMenu />
 
                         <Tooltip label="Media Search" position="top" withArrow>
@@ -230,7 +229,6 @@ const AppNav: FC<AppNavProps> = ({ noBackground = false }) => {
                     </Flex>
 
                     <Flex gap={10} align="center">
-                        <WaitingOnAPIIndicator stealth />
                         <SystemPower />
                     </Flex>
                 </Flex>

--- a/src/components/app/layout/RootLayout.tsx
+++ b/src/components/app/layout/RootLayout.tsx
@@ -38,7 +38,7 @@ import WelcomeMessage from "../WelcomeMessage";
 //
 // Contents:
 //  - The main application shell (which holds the header, navigation, and active feature/screen).
-//  - The background image based on currently-playing art (for Current Track and Playlist screens).
+//  - The background image based on currently-playing art (for Current and Playlist screens).
 //  - Occasional components which want to render on top of the base application:
 //      - Keyboard shortcuts.
 //      - Debug panel.

--- a/src/components/app/managers/KeyboardShortcutsManager.tsx
+++ b/src/components/app/managers/KeyboardShortcutsManager.tsx
@@ -305,7 +305,7 @@ const KeyboardShortcutsManager: FC = () => {
                             </Stack>
                             <FieldValueList
                                 fieldValues={{
-                                    C: "Current Track",
+                                    C: "Current",
                                     P: "Playlist",
                                     R: "Artists",
                                     A: "Albums",

--- a/src/components/shared/playbackControls/PlaybackControls.tsx
+++ b/src/components/shared/playbackControls/PlaybackControls.tsx
@@ -40,8 +40,8 @@ const PlaybackControls: FC = () => {
      * If the playStatus has been "buffering" for at least BUFFERING_AUDIO_NOTIFY_DELAY ms, then
      * display a "buffering" overlay.
      *
-     * Do not show this overlay if on the Current Track screen (which has its own fullscreen
-     * overlay for the buffering state).
+     * Do not show this overlay if on the Current screen (which has its own fullscreen overlay for
+     * the buffering state).
      */
     useEffect(() => {
         if (playStatus === "buffering" && currentScreen !== "current") {


### PR DESCRIPTION
- Rename "Current Track" screen to "Current"
- Shrink nav bar width
- Remove `<MediaSourceBadge>` (it's shown in "Current" screen)
- Move `<WaitingOnAPIIndicator>` above bottom nav bar buttons