### PR TITLE
Improve determination of whether to show loader in media walls

### DIFF
--- a/src/components/features/presets/PresetsWall.tsx
+++ b/src/components/features/presets/PresetsWall.tsx
@@ -55,6 +55,7 @@ const PresetsWall: FC<PresetsWallProps> = ({
         (state: RootState) => state.userSettings.presets
     );
     const [presetsToDisplay, setPresetsToDisplay] = useState<Preset[]>([]);
+    const [haveProcessedPresets, setHaveProcessedPresets] = useState<boolean>(false);
 
     // NOTE: The PresetWall differs from the Artists/Albums/Tracks walls in that it gets its data
     //  (the presets) directly from the redux state, not from an API call. This is because Presets
@@ -83,6 +84,10 @@ const PresetsWall: FC<PresetsWallProps> = ({
      * Determine which Presets to display based on the current filter text.
      */
     useEffect(() => {
+        if (!haveReceivedInitialState) {
+            return;
+        }
+
         onIsFilteringUpdate && onIsFilteringUpdate(true);
 
         let processedPresets = collectionFilter(presets || [], filterText, "name")
@@ -90,12 +95,15 @@ const PresetsWall: FC<PresetsWallProps> = ({
             .sort(collectionSorter(sortField || wallSortField, sortDirection || wallSortDirection));
 
         dispatch(setFilteredPresetIds(processedPresets.map((preset) => preset.id)));
+
         setPresetsToDisplay(processedPresets);
+        setHaveProcessedPresets(true);
 
         onIsFilteringUpdate && onIsFilteringUpdate(false);
     }, [
         dispatch,
         filterText,
+        haveReceivedInitialState,
         onIsFilteringUpdate,
         presets,
         sortDirection,
@@ -104,7 +112,7 @@ const PresetsWall: FC<PresetsWallProps> = ({
         wallSortField,
     ]);
 
-    if (!haveReceivedInitialState) {
+    if (!haveReceivedInitialState || !haveProcessedPresets) {
         return (
             <Center pt={SCREEN_LOADING_PT}>
                 <Loader variant="dots" size="md" />

--- a/src/components/features/tracks/TracksWall.tsx
+++ b/src/components/features/tracks/TracksWall.tsx
@@ -63,11 +63,18 @@ const TracksWall: FC<TrackWallProps> = ({
         (state: RootState) => state.playback.current_track_media_id
     );
     const mediaServer = useAppSelector((state: RootState) => state.system.media_server);
-    const { data: allTracks, error, isLoading, status: allTracksStatus } = useGetTracksQuery();
+    const {
+        data: allTracks,
+        error,
+        isLoading: isLoadingAllTracks,
+        status: allTracksStatus,
+    } = useGetTracksQuery();
     const [searchLyrics, { data: tracksMatchingLyrics, isLoading: isLoadingSearchLyrics }] =
         useSearchLyricsMutation();
-    const [calculatingTracksToDisplay, setCalculatingTracksToDisplay] = useState<boolean>(false);
+    const [calculatingTracksToDisplay, setCalculatingTracksToDisplay] = useState<boolean>(true);
     const [tracksToDisplay, setTracksToDisplay] = useState<Track[]>([]);
+
+    console.log(`TOP: ${calculatingTracksToDisplay} :: ${tracksToDisplay.length}`);
 
     const { classes: dynamicClasses } = createStyles((theme) => ({
         cardWall: {
@@ -102,6 +109,10 @@ const TracksWall: FC<TrackWallProps> = ({
      * of any lyrics search.
      */
     useEffect(() => {
+        if (isLoadingAllTracks) {
+            return;
+        }
+
         if (allTracksStatus === QueryStatus.rejected) {
             // Inability to retrieve All Tracks is considered a significant-enough problem to stop
             // trying to proceed.
@@ -140,6 +151,7 @@ const TracksWall: FC<TrackWallProps> = ({
             .sort(collectionSorter(sortField || wallSortField, sortDirection || wallSortDirection));
 
         dispatch(setFilteredTrackMediaIds(processedTracks.map((track) => track.id)));
+
         setTracksToDisplay(processedTracks);
         setCalculatingTracksToDisplay(false);
     }, [
@@ -148,6 +160,7 @@ const TracksWall: FC<TrackWallProps> = ({
         debouncedFilterText,
         dispatch,
         filterText,
+        isLoadingAllTracks,
         lyricsSearchText,
         sortDirection,
         sortField,
@@ -199,7 +212,7 @@ const TracksWall: FC<TrackWallProps> = ({
         );
     }
 
-    if (isLoading) {
+    if (isLoadingAllTracks) {
         return (
             <Center pt={SCREEN_LOADING_PT}>
                 <LoadingDataMessage message="Retrieving tracks..." />


### PR DESCRIPTION
This removes the brief incorrect flashes of "No {...} to display" messages.