### PR TITLE
Formalize support for "year" media metadata

### DIFF
--- a/src/app/hooks/useAppGlobals.ts
+++ b/src/app/hooks/useAppGlobals.ts
@@ -60,19 +60,19 @@ export const useAppGlobals = () => {
         SEEK_OFFSET_SECS: 10,
         SCROLL_POS_DISPATCH_RATE: 500,
         SELECTED_COLOR: "rgba(25, 113, 194, 0.2)",
-        SORTABLE_MEDIA_FIELDS_ALBUMS: ["artist", "date", "genre", "title"],
-        SORTABLE_MEDIA_FIELDS_FAVORITES: ["album", "artist", "date", "duration", "genre", "title"],
+        SORTABLE_MEDIA_FIELDS_ALBUMS: ["artist", "year", "genre", "title"],
+        SORTABLE_MEDIA_FIELDS_FAVORITES: ["album", "artist", "year", "duration", "genre", "title"],
         SORTABLE_MEDIA_FIELDS_MEDIA_SEARCH: [
             "album",
             "artist",
-            "date",
+            "year",
             "duration",
             "genre",
             "name",
             "title",
         ],
         SORTABLE_MEDIA_FIELDS_PRESETS: ["id", "name", "type"],
-        SORTABLE_MEDIA_FIELDS_TRACKS: ["album", "artist", "date", "duration", "genre", "title"],
+        SORTABLE_MEDIA_FIELDS_TRACKS: ["album", "artist", "year", "duration", "genre", "title"],
         BUFFERING_AUDIO_NOTIFY_DELAY: 3000,
         STYLE_LABEL_BESIDE_COMPONENT: {
             root: {

--- a/src/app/services/vibinAlbums.ts
+++ b/src/app/services/vibinAlbums.ts
@@ -39,20 +39,42 @@ export type BackendTrack = {
     original_track_number: string;
 };
 
-export const trackTransformer = (track: BackendTrack): Track => ({
-    id: track.id,
-    albumId: track.albumId,
-    parentId: track.parentId,
-    track_number: parseInt(track.original_track_number, 10),
-    duration: hmsToSecs(track.duration),
-    album: track.album,
-    artist: track.artist,
-    title: track.title,
-    art_url: track.album_art_uri,
-    album_art_uri: track.album_art_uri,
-    date: track.date,
-    genre: track.genre,
-});
+export const albumTransformer = (album: BackendAlbum): Album => {
+    const date = new Date(album.date);
+    const year = date.getFullYear();
+
+    return {
+        id: album.id,
+        title: album.title,
+        creator: album.artist,
+        date: album.date,
+        year: isNaN(year) ? 0 : year,
+        artist: album.artist,
+        genre: album.genre,
+        album_art_uri: album.album_art_uri,
+    }
+};
+
+export const trackTransformer = (track: BackendTrack): Track => {
+    const date = new Date(track.date);
+    const year = date.getFullYear();
+
+    return {
+        id: track.id,
+        albumId: track.albumId,
+        parentId: track.parentId,
+        track_number: parseInt(track.original_track_number, 10),
+        duration: hmsToSecs(track.duration),
+        album: track.album,
+        artist: track.artist,
+        title: track.title,
+        art_url: track.album_art_uri,
+        album_art_uri: track.album_art_uri,
+        date: track.date,
+        year: isNaN(year) ? 0 : year,
+        genre: track.genre,
+    }
+};
 
 export const vibinAlbumsApi = createApi({
     reducerPath: "vibinAlbumsApi",
@@ -61,12 +83,21 @@ export const vibinAlbumsApi = createApi({
     endpoints: (builder) => ({
         getAlbumById: builder.query<Album, MediaId>({
             query: (albumId) => albumId,
+            transformResponse(album: BackendAlbum): Promise<Album> | Album {
+                return albumTransformer(album);
+            },
         }),
         getAlbums: builder.query<Album[], void>({
             query: () => "",
+            transformResponse(albums: BackendAlbum[]): Promise<Album[]> | Album[] {
+                return albums.map(albumTransformer);
+            },
         }),
         getNewAlbums: builder.query<Album[], void>({
             query: () => "new",
+            transformResponse(albums: BackendAlbum[]): Promise<Album[]> | Album[] {
+                return albums.map(albumTransformer);
+            },
         }),
         getAlbumTracks: builder.query<Track[], string>({
             query: (albumMediaId) => `${albumMediaId}/tracks`,

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -34,6 +34,7 @@ export type Album = {
     title: string;
     creator: string;
     date: string;
+    year: number;
     artist: string;
     genre: string;
     album_art_uri: string; // TODO: This vs. art_url (be consistent; will need to rename somewhere)
@@ -74,6 +75,7 @@ export type Track = {
     title: string;
     // TODO: Fix up difference between a Track from /tracks/:id and the "current track" from the websocket
     date?: string;
+    year?: number;
     art_url: string;
     album_art_uri?: string;  // TODO: Fix "art_url" vs. "album_art_uri"
     genre?: string;

--- a/src/components/features/albums/AlbumsWall.tsx
+++ b/src/components/features/albums/AlbumsWall.tsx
@@ -243,7 +243,7 @@ const AlbumsWall: FC<AlbumWallProps> = ({
         <Box className={dynamicClasses.tableWall}>
             <MediaTable
                 media={albumsToDisplay}
-                columns={["album_art_uri", "title", "artist", "date", "genre"]}
+                columns={["album_art_uri", "title", "artist", "year", "genre"]}
                 stripeColor={tableStripeColor}
                 currentlyPlayingId={currentAlbumMediaId}
                 currentlyPlayingRef={currentAlbumRef}

--- a/src/components/features/favorites/FavoritesWall.tsx
+++ b/src/components/features/favorites/FavoritesWall.tsx
@@ -244,7 +244,7 @@ const FavoritesWall: FC<FavoritesWallProps> = ({
                             <Box className={dynamicClasses.tableWall}>
                                 <MediaTable
                                     media={albumsToDisplay}
-                                    columns={["album_art_uri", "title", "artist", "date", "genre"]}
+                                    columns={["album_art_uri", "title", "artist", "year", "genre"]}
                                     stripeColor={tableStripeColor}
                                     currentlyPlayingId={currentAlbumMediaId}
                                 />
@@ -298,7 +298,7 @@ const FavoritesWall: FC<FavoritesWallProps> = ({
                                         "title",
                                         "artist",
                                         "album",
-                                        "date",
+                                        "year",
                                         "genre",
                                     ]}
                                     stripeColor={tableStripeColor}

--- a/src/components/features/tracks/TracksWall.tsx
+++ b/src/components/features/tracks/TracksWall.tsx
@@ -250,7 +250,7 @@ const TracksWall: FC<TrackWallProps> = ({
         <Box className={dynamicClasses.tableWall}>
             <MediaTable
                 media={tracksToDisplay}
-                columns={["album_art_uri", "title", "artist", "album", "date", "duration", "genre"]}
+                columns={["album_art_uri", "title", "artist", "album", "year", "duration", "genre"]}
                 stripeColor={tableStripeColor}
                 currentlyPlayingId={currentTrackMediaId}
                 currentlyPlayingRef={currentTrackRef}


### PR DESCRIPTION
* Extract "year" (number) from "date" (string) metadata for `Album` and `Track` types
* Add "year" support to `<MediaTable>`
* Replace "date" with "year" in various media walls
* Enhance media filtering to support numeric types