### PR TITLE
Don't show `<FavoriteIndicator>` if current track is not local

### DIFF
--- a/src/components/features/CurrentTrackScreen.tsx
+++ b/src/components/features/CurrentTrackScreen.tsx
@@ -459,7 +459,10 @@ const CurrentTrackScreen: FC = () => {
                                     </Text>
                                 </Tooltip>
                             </Box>
-                            <FavoriteIndicator media={currentTrack} size="1.2rem" />
+
+                            {isLocalMediaActive && (
+                                <FavoriteIndicator media={currentTrack} size="1.2rem" />
+                            )}
                         </Flex>
 
                         {(isLocalMediaActive || currentTrack.artist || currentTrack.album) && (


### PR DESCRIPTION
This prevents attempts to favorite non-local tracks, such as those coming from AirPlay.