### PR TITLE
Fix preset art display issues

### DIFF
--- a/src/components/features/presets/PresetCard.tsx
+++ b/src/components/features/presets/PresetCard.tsx
@@ -121,6 +121,7 @@ const PresetCard: FC<PresetCardProps> = ({
             <Card.Section>
                 <MediaArt
                     media={preset}
+                    size={size}
                     showLoading={showLoading}
                     showActions={false}
                     showFavoriteIndicator={false}

--- a/src/components/shared/mediaDisplay/MediaArt.tsx
+++ b/src/components/shared/mediaDisplay/MediaArt.tsx
@@ -204,7 +204,7 @@ const MediaArt: FC<MediaArtProps> = ({
                         withPlaceholder={true}
                         placeholder={<NoArtPlaceholder artSize={size} radius={radius} />}
                         onLoad={() => setIsLoadingArt(false)}
-                        onError={(e) => setIsLoadingArt(false)}
+                        onError={() => setIsLoadingArt(false)}
                     />
                 </Skeleton>
             </Box>

--- a/src/components/shared/mediaDisplay/MediaArt.tsx
+++ b/src/components/shared/mediaDisplay/MediaArt.tsx
@@ -204,6 +204,7 @@ const MediaArt: FC<MediaArtProps> = ({
                         withPlaceholder={true}
                         placeholder={<NoArtPlaceholder artSize={size} radius={radius} />}
                         onLoad={() => setIsLoadingArt(false)}
+                        onError={(e) => setIsLoadingArt(false)}
                     />
                 </Skeleton>
             </Box>


### PR DESCRIPTION
* Handle art load network errors. Issue: Presets can include internet radio, and if the remotely-hosted internet radio art was unavailable then the media card's skeleton would never stop pulsing.
* `<PresetCard>` wasn't passing the preset size to `<MediaArt>`. This resulted in the art skeleton not consuming the available space while loading.