### PR TITLE
Treat volume as an integer, up to the amplifier's reported maximum

### DIFF
--- a/src/app/services/vibinSystem.ts
+++ b/src/app/services/vibinSystem.ts
@@ -30,7 +30,7 @@ export const vibinSystemApi = createApi({
             query: () => ({ url: `amplifier/volume/down`, method: "POST" }),
         }),
         amplifierVolumeSet: builder.mutation<void, number>({
-            query: (volume) => ({ url: `amplifier/volume/${volume.toFixed(2)}`, method: "POST" }),
+            query: (volume) => ({ url: `amplifier/volume/${volume}`, method: "POST" }),
         }),
         amplifierVolumeUp: builder.mutation<void, void>({
             query: () => ({ url: `amplifier/volume/up`, method: "POST" }),

--- a/src/app/services/vibinWebsocket.ts
+++ b/src/app/services/vibinWebsocket.ts
@@ -140,6 +140,7 @@ type SystemPayload = {
         supported_actions: AmplifierAction[] | undefined;
         power: "on" | "off" | undefined;
         mute: "on" | "off" | undefined;
+        max_volume: number | undefined;
         volume: number | undefined;
         sources: {
             active: AudioSource,

--- a/src/app/store/systemSlice.ts
+++ b/src/app/store/systemSlice.ts
@@ -68,6 +68,7 @@ export interface AmplifierState extends DeviceState {
     supported_actions: AmplifierAction[] | undefined;
     power: PowerState | undefined;
     mute: MuteState | undefined;
+    max_volume: number | undefined;
     volume: number | undefined;
     sources: AudioSources | undefined;
 }
@@ -95,6 +96,7 @@ const initialState: SystemState = {
         supported_actions: [],
         power: undefined,
         mute: undefined,
+        max_volume: undefined,
         volume: undefined,
         sources: undefined,
     },

--- a/src/components/features/StatusScreen.tsx
+++ b/src/components/features/StatusScreen.tsx
@@ -152,8 +152,9 @@ const StatusScreen: FC = () => {
             dispatch(setApplicationAmplifierMaxVolume(normalizedMaxVolume));
 
             amplifier?.volume &&
-                normalizedMaxVolume < amplifier.volume &&
-                volumeSet(normalizedMaxVolume);
+                amplifier.max_volume &&
+                normalizedMaxVolume * amplifier.max_volume < amplifier.volume &&
+                volumeSet(Math.floor(normalizedMaxVolume * amplifier.max_volume));
 
             showSuccessNotification({ title: "Maximum volume updated" });
         }, [normalizedMaxVolume, amplifier, dispatch, volumeSet]);


### PR DESCRIPTION
Counterpart to https://github.com/mjoblin/vibin/pull/133

Shows the amplifier's native volume value, up to the amplifier's own maximum value.

This PR leaves vibinui's soft volume max setting as a value 0-100 and treats it as a percentage of the amplifier's own maximum. I'll raise a bug to cover potential improvements there.