### PR TITLE
Soft volume limit uses integer values

### DIFF
--- a/src/app/store/localStorageMiddleware.ts
+++ b/src/app/store/localStorageMiddleware.ts
@@ -12,7 +12,6 @@ import {
     LSKEY_ALBUMS_WALL_SORT_DIRECTION,
     LSKEY_ALBUMS_WALL_SORT_FIELD,
     LSKEY_ALBUMS_WALL_VIEW_MODE,
-    LSKEY_APPLICATION_AMPLIFIER_MAX_VOLUME,
     LSKEY_APPLICATION_AUTO_PLAY_ON_PLAYLIST_ACTIVATION,
     LSKEY_APPLICATION_HAVE_SHOWN_WELCOME_MESSAGE,
     LSKEY_APPLICATION_MEDIA_SEARCH_CARD_GAP,
@@ -25,6 +24,7 @@ import {
     LSKEY_APPLICATION_MEDIA_SEARCH_WALL_VIEW_MODE,
     LSKEY_APPLICATION_THEME,
     LSKEY_APPLICATION_USE_IMAGE_BACKGROUND,
+    LSKEY_APPLICATION_VOLUME_LIMIT,
     LSKEY_ARTISTS_ACTIVE_COLLECTION,
     LSKEY_ARTISTS_CARD_GAP,
     LSKEY_ARTISTS_CARD_SIZE,
@@ -70,7 +70,6 @@ import {
     setAlbumsWallSortDirection,
     setAlbumsWallSortField,
     setAlbumsWallViewMode,
-    setApplicationAmplifierMaxVolume,
     setApplicationAutoPlayOnPlaylistActivation,
     setApplicationHaveShownWelcomeMessage,
     setApplicationMediaSearchCardGap,
@@ -83,6 +82,7 @@ import {
     setApplicationMediaSearchWallViewMode,
     setApplicationTheme,
     setApplicationUseImageBackground,
+    setApplicationVolumeLimit,
     setArtistsActiveCollection,
     setArtistsCardGap,
     setArtistsCardSize,
@@ -148,7 +148,6 @@ export const actionToLocalStorageKeyMapper: Record<string, string> = {
     [setAlbumsWallSortDirection.type]: LSKEY_ALBUMS_WALL_SORT_DIRECTION,
     [setAlbumsWallSortField.type]: LSKEY_ALBUMS_WALL_SORT_FIELD,
     [setAlbumsWallViewMode.type]: LSKEY_ALBUMS_WALL_VIEW_MODE,
-    [setApplicationAmplifierMaxVolume.type]: LSKEY_APPLICATION_AMPLIFIER_MAX_VOLUME,
     [setApplicationAutoPlayOnPlaylistActivation.type]: LSKEY_APPLICATION_AUTO_PLAY_ON_PLAYLIST_ACTIVATION,
     [setApplicationHaveShownWelcomeMessage.type]: LSKEY_APPLICATION_HAVE_SHOWN_WELCOME_MESSAGE,
     [setApplicationMediaSearchCardGap.type]: LSKEY_APPLICATION_MEDIA_SEARCH_CARD_GAP,
@@ -162,6 +161,7 @@ export const actionToLocalStorageKeyMapper: Record<string, string> = {
     [setApplicationMediaSearchWallViewMode.type]: LSKEY_APPLICATION_MEDIA_SEARCH_WALL_VIEW_MODE,
     [setApplicationTheme.type]: LSKEY_APPLICATION_THEME,
     [setApplicationUseImageBackground.type]: LSKEY_APPLICATION_USE_IMAGE_BACKGROUND,
+    [setApplicationVolumeLimit.type]: LSKEY_APPLICATION_VOLUME_LIMIT,
     [setArtistsActiveCollection.type]: LSKEY_ARTISTS_ACTIVE_COLLECTION,
     [setArtistsCardGap.type]: LSKEY_ARTISTS_CARD_GAP,
     [setArtistsCardSize.type]: LSKEY_ARTISTS_CARD_SIZE,
@@ -210,7 +210,6 @@ localStorageMiddleware.startListening({
         setAlbumsWallSortDirection,
         setAlbumsWallSortField,
         setAlbumsWallViewMode,
-        setApplicationAmplifierMaxVolume,
         setApplicationAutoPlayOnPlaylistActivation,
         setApplicationHaveShownWelcomeMessage,
         setApplicationMediaSearchCardGap,
@@ -223,6 +222,7 @@ localStorageMiddleware.startListening({
         setApplicationMediaSearchWallViewMode,
         setApplicationTheme,
         setApplicationUseImageBackground,
+        setApplicationVolumeLimit,
         setArtistsActiveCollection,
         setArtistsCardGap,
         setArtistsCardSize,
@@ -313,10 +313,13 @@ localStorageMiddleware.startListening({
         // Store the given key/value pair in local storage. Local storage wants string values, so
         // JSON.stringify() is used. Anything wishing to use these stored values (userSettingsSlice)
         // needs to run them through JSON.parse().
-        key &&
-            value !== null &&
-            value !== undefined &&
-            localStorage.setItem(key, JSON.stringify(value));
+        if (key) {
+            if (value !== null && value !== undefined) {
+                localStorage.setItem(key, JSON.stringify(value));
+            } else {
+                localStorage.removeItem(key);
+            }
+        }
     },
 });
 

--- a/src/app/store/userSettingsSlice.ts
+++ b/src/app/store/userSettingsSlice.ts
@@ -24,7 +24,6 @@ const DEFAULT_ALBUMS_SHOW_DETAILS = true;
 const DEFAULT_ALBUMS_WALL_SORT_FIELD = "title";
 const DEFAULT_ALBUMS_WALL_SORT_DIRECTION = "ascending";
 const DEFAULT_ALBUMS_WALL_VIEW_MODE = "cards";
-const DEFAULT_APPLICATION_AMPLIFIER_MAX_VOLUME = 0.5;
 const DEFAULT_APPLICATION_AUTO_PLAY_ON_PLAYLIST_ACTIVATION = true;
 const DEFAULT_APPLICATION_HAVE_SHOWN_WELCOME_MESSAGE = false;
 const DEFAULT_APPLICATION_MEDIA_SEARCH_CARD_GAP = 15;
@@ -42,6 +41,7 @@ const DEFAULT_APPLICATION_MEDIA_SEARCH_WALL_SORT_DIRECTION = "ascending";
 const DEFAULT_APPLICATION_MEDIA_SEARCH_WALL_VIEW_MODE = "cards";
 const DEFAULT_APPLICATION_THEME = "dark";
 const DEFAULT_APPLICATION_USE_IMAGE_BACKGROUND = true;
+const DEFAULT_APPLICATION_VOLUME_LIMIT = null;
 const DEFAULT_ARTISTS_ACTIVE_COLLECTION = "with_albums";
 const DEFAULT_ARTISTS_CARD_SIZE = DEFAULT_ALBUMS_CARD_SIZE;
 const DEFAULT_ARTISTS_CARD_GAP = DEFAULT_ALBUMS_CARD_GAP;
@@ -87,7 +87,6 @@ export const LSKEY_ALBUMS_SHOW_DETAILS = "albums.showDetails";
 export const LSKEY_ALBUMS_WALL_SORT_DIRECTION = "albums.wallSortDirection";
 export const LSKEY_ALBUMS_WALL_SORT_FIELD = "albums.wallSortField";
 export const LSKEY_ALBUMS_WALL_VIEW_MODE = "albums.wallViewMode";
-export const LSKEY_APPLICATION_AMPLIFIER_MAX_VOLUME = "application.amplifierMaxVolume";
 export const LSKEY_APPLICATION_AUTO_PLAY_ON_PLAYLIST_ACTIVATION = "application.autoPlayOnPlaylistActivation";
 export const LSKEY_APPLICATION_HAVE_SHOWN_WELCOME_MESSAGE = "application.haveShownWelcomeMessage";
 export const LSKEY_APPLICATION_MEDIA_SEARCH_CARD_GAP = "application.mediaSearch.cardGap";
@@ -100,6 +99,7 @@ export const LSKEY_APPLICATION_MEDIA_SEARCH_WALL_SORT_FIELD = "application.media
 export const LSKEY_APPLICATION_MEDIA_SEARCH_WALL_VIEW_MODE = "application.mediaSearch.wallViewMode";
 export const LSKEY_APPLICATION_THEME = "application.theme";
 export const LSKEY_APPLICATION_USE_IMAGE_BACKGROUND = "application.useImageBackground";
+export const LSKEY_APPLICATION_VOLUME_LIMIT = "application.volumeLimit";
 export const LSKEY_ARTISTS_ACTIVE_COLLECTION = "artists.activeCollection";
 export const LSKEY_ARTISTS_CARD_GAP = "artists.cardGap";
 export const LSKEY_ARTISTS_CARD_SIZE = "artists.cardSize";
@@ -159,7 +159,6 @@ export interface UserSettingsState {
         wallViewMode: MediaWallViewMode;
     };
     application: {
-        amplifierMaxVolume: number;
         autoPlayOnPlaylistActivation: boolean;
         haveShownWelcomeMessage: boolean;
         mediaSearch: {
@@ -174,6 +173,7 @@ export interface UserSettingsState {
         }
         theme: ApplicationTheme;
         useImageBackground: boolean;
+        volumeLimit: number | null;
     };
     artists: {
         activeCollection: ArtistCollection;
@@ -270,10 +270,6 @@ const initialState: UserSettingsState = {
         ),
     },
     application: {
-        amplifierMaxVolume: getLocalStorageValue(
-            LSKEY_APPLICATION_AMPLIFIER_MAX_VOLUME,
-            DEFAULT_APPLICATION_AMPLIFIER_MAX_VOLUME
-        ),
         autoPlayOnPlaylistActivation: getLocalStorageValue(
             LSKEY_APPLICATION_AUTO_PLAY_ON_PLAYLIST_ACTIVATION,
             DEFAULT_APPLICATION_AUTO_PLAY_ON_PLAYLIST_ACTIVATION
@@ -320,6 +316,10 @@ const initialState: UserSettingsState = {
         useImageBackground: getLocalStorageValue(
             LSKEY_APPLICATION_USE_IMAGE_BACKGROUND,
             DEFAULT_APPLICATION_USE_IMAGE_BACKGROUND
+        ),
+        volumeLimit: getLocalStorageValue(
+            LSKEY_APPLICATION_VOLUME_LIMIT,
+            DEFAULT_APPLICATION_VOLUME_LIMIT
         ),
     },
     artists: {
@@ -488,9 +488,6 @@ export const userSettingsSlice = createSlice({
         setAlbumsWallViewMode: (state, action: PayloadAction<MediaWallViewMode>) => {
             state.albums.wallViewMode = action.payload;
         },
-        setApplicationAmplifierMaxVolume: (state, action: PayloadAction<number>) => {
-            state.application.amplifierMaxVolume = action.payload;
-        },
         setApplicationAutoPlayOnPlaylistActivation: (state, action: PayloadAction<boolean>) => {
             state.application.autoPlayOnPlaylistActivation = action.payload;
         },
@@ -529,6 +526,9 @@ export const userSettingsSlice = createSlice({
         },
         setApplicationUseImageBackground: (state, action: PayloadAction<boolean>) => {
             state.application.useImageBackground = action.payload;
+        },
+        setApplicationVolumeLimit: (state, action: PayloadAction<number | null>) => {
+            state.application.volumeLimit = action.payload;
         },
         setArtistsActiveCollection: (state, action: PayloadAction<ArtistCollection>) => {
             state.artists.activeCollection = action.payload;
@@ -661,7 +661,6 @@ export const {
     setAlbumsWallSortDirection,
     setAlbumsWallSortField,
     setAlbumsWallViewMode,
-    setApplicationAmplifierMaxVolume,
     setApplicationAutoPlayOnPlaylistActivation,
     setApplicationHaveShownWelcomeMessage,
     setApplicationMediaSearchCardGap,
@@ -674,6 +673,7 @@ export const {
     setApplicationMediaSearchWallViewMode,
     setApplicationTheme,
     setApplicationUseImageBackground,
+    setApplicationVolumeLimit,
     setArtistsActiveCollection,
     setArtistsCardGap,
     setArtistsCardSize,

--- a/src/components/app/managers/KeyboardShortcutsManager.tsx
+++ b/src/components/app/managers/KeyboardShortcutsManager.tsx
@@ -38,8 +38,8 @@ const KeyboardShortcutsManager: FC = () => {
     const { showKeyboardShortcuts } = useAppSelector(
         (state: RootState) => state.internal.application
     );
-    const volumeLimitFraction = useAppSelector(
-        (state: RootState) => state.userSettings.application.amplifierMaxVolume
+    const applicationVolumeLimit = useAppSelector(
+        (state: RootState) => state.userSettings.application.volumeLimit
     );
     const playStatus = useAppSelector((state: RootState) => state.playback.play_status);
     const activeTransportActions = useAppSelector(
@@ -79,9 +79,7 @@ const KeyboardShortcutsManager: FC = () => {
     const largeVolumeDelta = 5;
 
     // Avoid setting the volume above the limit set in the status page
-    const volumeLimit = amplifier.max_volume
-        ? amplifier.max_volume * volumeLimitFraction
-        : Number.MAX_VALUE;
+    const volumeLimit = applicationVolumeLimit ?? amplifier?.max_volume ?? Number.MAX_VALUE;
 
     /**
      * Whenever the local volume state changes, send a volumeSet request to the amplifier.

--- a/src/components/shared/buttons/VolumeControl.tsx
+++ b/src/components/shared/buttons/VolumeControl.tsx
@@ -40,8 +40,8 @@ const VolumeControl: FC = () => {
     const [amplifierVolumeSet] = useAmplifierVolumeSetMutation();
     const [amplifierMuteToggle] = useAmplifierMuteToggleMutation();
     const [localVolume, setLocalVolume] = useState<number>(0);
-    const volumeLimitFraction = useAppSelector(
-        (state: RootState) => state.userSettings.application.amplifierMaxVolume
+    const applicationVolumeLimit = useAppSelector(
+        (state: RootState) => state.userSettings.application.volumeLimit
     );
 
     const isAmpOn = amplifier?.power === "on";
@@ -67,7 +67,7 @@ const VolumeControl: FC = () => {
     }
 
     const { mute, volume, max_volume } = amplifier;
-    const volumeLimit = volumeLimitFraction * max_volume;
+    const volumeLimit = applicationVolumeLimit ?? max_volume;
 
     // RingProgress uses values out of 100
     const progressCurrentVolume = (volume * 100) / max_volume;


### PR DESCRIPTION
Changes the volume limiter, available in the Status screen, to use the same units as the amplifier's native volume step. Instead of setting a percentage value, the user just sets a maximum integer volume value.

I've changed the previous setting name (`application.amplifierMaxVolume`) to `application.volumeLimit`, and changed references to "max volume" to "volume limit" throughout. Partly this distinguishes more clearly from the Amplifier.max_volume property, and partly it means we don't need to handle old percentage values. It does mean that any users will need to reset their maximum.

It also changes the default from 50% to being unlimited, which I think is more natural.

Fixes #271