### PR TITLE
Better support for volume controls provided by the streamer

### DIFF
--- a/src/components/app/SettingsMenu.tsx
+++ b/src/components/app/SettingsMenu.tsx
@@ -24,7 +24,7 @@ import {
     useAmplifierPowerToggleMutation,
     useAmplifierSourceSetMutation,
     useStreamerPowerToggleMutation,
-    useStreamerSourceSetMutation
+    useStreamerSourceSetMutation,
 } from "../../app/services/vibinSystem";
 import {
     setShowDebugPanel,
@@ -94,8 +94,8 @@ const SettingsMenu: FC = () => {
         checkIfPowerChanged("Streamer", streamer.power, previousStreamerPowerState);
     }, [amplifier?.power, streamer.power]);
 
-    const showAmplifierPower = amplifier?.power != null
-    const showAmplifierSources = amplifier?.sources != null
+    const showAmplifierPower = amplifier?.power != null;
+    const showAmplifierSources = amplifier?.sources != null;
     const isAmpAvailable =
         amplifier && (amplifier.power ? amplifier.power === "on" : system.power === "on");
 

--- a/src/components/features/StatusScreen.tsx
+++ b/src/components/features/StatusScreen.tsx
@@ -267,6 +267,7 @@ const StatusScreen: FC = () => {
                             rowHeight={1.3}
                             fieldValues={{
                                 Streamer: streamer.name || "",
+                                Amplifier: amplifier?.name || "<none>",
                                 "Media Server": mediaServer?.name || "<none>",
                                 "Play State": <PlayStateIndicator />,
                                 Source: <MediaSourceBadge />,

--- a/src/components/shared/buttons/VolumeControl.tsx
+++ b/src/components/shared/buttons/VolumeControl.tsx
@@ -36,7 +36,7 @@ const VolumeControl: FC = () => {
     const { colors } = useMantineTheme();
     const [opened, { close, open }] = useDisclosure(false);
     const { HEADER_HEIGHT } = useAppGlobals();
-    const amplifier = useAppSelector((state: RootState) => state.system.amplifier);
+    const system = useAppSelector((state: RootState) => state.system);
     const [amplifierVolumeSet] = useAmplifierVolumeSetMutation();
     const [amplifierMuteToggle] = useAmplifierMuteToggleMutation();
     const [localVolume, setLocalVolume] = useState<number>(0);
@@ -44,8 +44,10 @@ const VolumeControl: FC = () => {
         (state: RootState) => state.userSettings.application.volumeLimit
     );
 
-    const isAmpOn = amplifier?.power === "on";
-    const canControlMute = amplifier?.mute === "on" || amplifier?.mute === "off";
+    const amplifier = system.amplifier;
+    const isAmpOn =
+        amplifier && (amplifier.power ? amplifier.power === "on" : system.power === "on");
+    const canControlMute = amplifier?.supported_actions?.includes("mute");
 
     /**
      * Whenever a new volume setting comes in from the amplifier, force our local volume state
@@ -59,7 +61,6 @@ const VolumeControl: FC = () => {
     if (
         !amplifier ||
         amplifier.mute === null ||
-        amplifier.power == null ||
         amplifier.max_volume == null ||
         amplifier.volume == null
     ) {

--- a/src/components/shared/buttons/VolumeUpDownControl.tsx
+++ b/src/components/shared/buttons/VolumeUpDownControl.tsx
@@ -16,25 +16,27 @@ import { useAppGlobals } from "../../../app/hooks/useAppGlobals";
 const VolumeUpDownControl: FC = () => {
     const theme = useMantineTheme();
     const { STYLE_DISABLEABLE } = useAppGlobals();
-    const amplifier = useAppSelector((state: RootState) => state.system.amplifier);
+    const system = useAppSelector((state: RootState) => state.system);
     const [amplifierVolumeUp] = useAmplifierVolumeUpMutation();
     const [amplifierVolumeDown] = useAmplifierVolumeDownMutation();
 
-    const isAmpOff = amplifier?.power === "off";
+    const amplifier = system.amplifier;
+    const isAmpOn =
+        amplifier && (amplifier.power ? amplifier.power === "on" : system.power === "on");
     const colorStandard =
         theme.colorScheme === "dark" ? theme.colors.dark[1] : theme.colors.dark[3];
 
     return (
         <Flex gap={1} align="center">
             <ActionIcon
-                disabled={isAmpOff}
+                disabled={!isAmpOn}
                 sx={STYLE_DISABLEABLE}
                 onClick={() => amplifierVolumeDown()}
             >
                 <IconSquareRoundedMinusFilled style={{ color: colorStandard }} />
             </ActionIcon>
             <ActionIcon
-                disabled={isAmpOff}
+                disabled={!isAmpOn}
                 sx={STYLE_DISABLEABLE}
                 onClick={() => amplifierVolumeUp()}
             >


### PR DESCRIPTION
Allows the `PowerState` to be omitted by amplifier implementations for which the power status is unavailable or simply a duplicate of the streamer's status. Disability of volume controls will use the system power status in this case. Also conditionally omits UI relating to the amplifier from the cog menu.

Fixes #281, in conjunction with a server-side pull request which I'll upload shortly.